### PR TITLE
Remove individual X,Y,Z homing from delta printers

### DIFF
--- a/Repetier/uimenu.h
+++ b/Repetier/uimenu.h
@@ -229,8 +229,13 @@ UI_MENU_ACTIONSELECTOR(ui_menu_go_xfast,UI_TEXT_X_POS_FAST,ui_menu_xpos_fast);
 UI_MENU_ACTIONSELECTOR(ui_menu_go_yfast,UI_TEXT_Y_POS_FAST,ui_menu_ypos_fast);
 UI_MENU_ACTIONSELECTOR(ui_menu_go_zfast,UI_TEXT_Z_POS_FAST,ui_menu_zpos_fast);
 
+#if DRIVE_SYSTEM!=3     //Positioning menu for non-delta
 #define UI_MENU_POSITIONS {UI_MENU_ADDCONDBACK &ui_menu_home_all,&ui_menu_home_x,&ui_menu_home_y,&ui_menu_home_z,&ui_menu_go_xfast,&ui_menu_go_xpos,&ui_menu_go_yfast,&ui_menu_go_ypos,&ui_menu_go_zfast,&ui_menu_go_zpos,&ui_menu_go_epos}
 UI_MENU(ui_menu_positions,UI_MENU_POSITIONS,11+UI_MENU_BACKCNT);
+#else                   //Positioning menu for delta (removes individual x,y,z homing)
+#define UI_MENU_POSITIONS {UI_MENU_ADDCONDBACK &ui_menu_home_all,&ui_menu_go_xfast,&ui_menu_go_xpos,&ui_menu_go_yfast,&ui_menu_go_ypos,&ui_menu_go_zfast,&ui_menu_go_zpos,&ui_menu_go_epos}
+UI_MENU(ui_menu_positions,UI_MENU_POSITIONS,8+UI_MENU_BACKCNT);
+#endif
 
 // **** Delta calibration menu
 #ifdef STEP_COUNTER


### PR DESCRIPTION
Auto-Removes individual homing of x,y,z from the LCD menu when printer is delta where not only is it not useful but can easily cause movement outside the limits of the platform possibly damaging an arm.
