### PR TITLE
OPS Menu bug fix

### DIFF
--- a/Repetier/ui.cpp
+++ b/Repetier/ui.cpp
@@ -1521,7 +1521,7 @@ void UIDisplay::nextPreviousAction(char next) {
   case UI_ACTION_OPS_MOVE_AFTER:
     printer_state.opsMoveAfter+=increment;
     if(printer_state.opsMoveAfter<0) printer_state.opsMoveAfter=0;
-    else if(printer_state.opsMoveAfter>10) printer_state.opsMoveAfter=100;
+    else if(printer_state.opsMoveAfter>100) printer_state.opsMoveAfter=100;
     extruder_select(current_extruder->id);
     break;
   case UI_ACTION_OPS_MINDISTANCE:


### PR DESCRIPTION
Fixes a bug where the "move after" setting in the OPS menu becomes
unchangeable as it defaults to 100% for any value above 10%.
