### PR TITLE
Add support for AD8495/6/7/8

### DIFF
--- a/Repetier/Configuration.h
+++ b/Repetier/Configuration.h
@@ -171,6 +171,7 @@ the wrong direction change INVERT_X_DIR or INVERT_Y_DIR.
 // 50 is userdefined thermistor table 0 for PTC thermistors
 // 51 is userdefined thermistor table 0 for PTC thermistors
 // 52 is userdefined thermistor table 0 for PTC thermistors
+// 60 is AD8494, AD8495, AD8496 or AD8497 (5mV/°C and 1/4 the price of AD595 but only MSOT_08 package)
 // 97 Generic thermistor table 1
 // 98 Generic thermistor table 2
 // 99 Generic thermistor table 3
@@ -280,6 +281,7 @@ The codes are only executed for multiple extruder when changing the extruder. */
 // 50 is userdefined thermistor table 0 for PTC thermistors
 // 51 is userdefined thermistor table 0 for PTC thermistors
 // 52 is userdefined thermistor table 0 for PTC thermistors
+// 60 is AD8494, AD8495, AD8496 or AD8497 (5mV/°C and 1/4 the price of AD595 but only MSOT_08 package)
 // 97 Generic thermistor table 1
 // 98 Generic thermistor table 2
 // 99 Generic thermistor table 3

--- a/Repetier/Extruder.cpp
+++ b/Repetier/Extruder.cpp
@@ -609,6 +609,8 @@ int read_raw_temperature(byte type,byte pin) {
     case 51:
     case 52:
       return (osAnalogInputValues[pin]>>(ANALOG_REDUCE_BITS)); // Convert to 10 bit result    
+    case 60: // AD8495 (Delivers 5mV/°C)
+      return (osAnalogInputValues[pin]>>(ANALOG_REDUCE_BITS));
     case 100: // AD595
       return (osAnalogInputValues[pin]>>(ANALOG_REDUCE_BITS));
 #endif
@@ -679,6 +681,8 @@ float conv_raw_temp(byte type,int raw_temp) {
       // Overflow: Set to last value in the table
       return TEMP_INT_TO_FLOAT(newtemp);
     }
+    case 60: // AD8495 (Delivers 5mV/°C vs the AD595's 10mV)
+      return ((float)raw_temp * 1000.0f/(1024<<(2-ANALOG_REDUCE_BITS)));
     case 100: // AD595
       //return (int)((long)raw_temp * 500/(1024<<(2-ANALOG_REDUCE_BITS)));
       return ((float)raw_temp * 500.0f/(1024<<(2-ANALOG_REDUCE_BITS)));
@@ -783,6 +787,8 @@ int conv_temp_raw(byte type,float tempf) {
       // Overflow: Set to last value in the table
       return newraw;
     }
+    case 60: // HEATER_USES_AD8495 (Delivers 5mV/°C)
+      return (int)((long)temp * (1024<<(2-ANALOG_REDUCE_BITS))/ 1000);
     case 100: // HEATER_USES_AD595
       return (int)((long)temp * (1024<<(2-ANALOG_REDUCE_BITS))/ 500);
 #ifdef SUPPORT_MAX6675


### PR DESCRIPTION
Tested for AD8495 using circuit from their datasheet and appnote.
http://www.analog.com/static/imported-files/data_sheets/AD8494_8495_8496_8497.pdf
The AD849x devices can drive up to 1k load so standard 4.7k pullup that may already be present on existing boards should not cause problems.
