### PR TITLE
fastio.h and pins.h fix for RAMBo by Ultimachine

### DIFF
--- a/Repetier/fastio.h
+++ b/Repetier/fastio.h
@@ -1364,6 +1364,8 @@ pins
 #define DIO69_DDR		DDRK
 #define DIO69_PWM		NULL
 
+
+
 #if MOTHERBOARD == 12
 #define DIO80_PIN		PINJ2
 #define DIO80_RPORT		PINJ
@@ -1436,6 +1438,74 @@ pins
 #define DIO94_WPORT		PORTD
 #define DIO94_DDR		DDRD
 #define DIO94_PWM		NULL
+
+
+//added below DIO definitions for RAMBo support for LCD's etc...
+#else
+
+#define DIO70_PIN       PING4
+#define DIO70_RPORT     PING
+#define DIO70_WPORT     PORTG
+#define DIO70_DDR       DDRG
+#define DIO70_PWM       NULL
+#define DIO71_PIN       PING3
+#define DIO71_RPORT     PING
+#define DIO71_WPORT     PORTG
+#define DIO71_DDR       DDRG
+#define DIO71_PWM       NULL
+#define DIO72_PIN       PINJ2
+#define DIO72_RPORT     PINJ
+#define DIO72_WPORT     PORTJ
+#define DIO72_DDR       DDRJ
+#define DIO72_PWM       NULL
+#define DIO73_PIN       PINJ3
+#define DIO73_RPORT     PINJ
+#define DIO73_WPORT     PORTJ
+#define DIO73_DDR       DDRJ
+#define DIO73_PWM       NULL
+#define DIO74_PIN       PINJ7
+#define DIO74_RPORT     PINJ
+#define DIO74_WPORT     PORTJ
+#define DIO74_DDR       DDRJ
+#define DIO74_PWM       NULL
+#define DIO75_PIN       PINJ4
+#define DIO75_RPORT     PINJ
+#define DIO75_WPORT     PORTJ
+#define DIO75_DDR       DDRJ
+#define DIO75_PWM       NULL
+
+
+#define DIO76_PIN       PINJ5
+#define DIO76_RPORT     PINJ
+#define DIO76_WPORT     PORTJ
+#define DIO76_DDR       DDRJ
+#define DIO76_PWM       NULL
+#define DIO77_PIN       PINJ6
+#define DIO77_RPORT     PINJ
+#define DIO77_WPORT     PORTJ
+#define DIO77_DDR       DDRJ
+#define DIO77_PWM       NULL
+#define DIO78_PIN       PINE2
+#define DIO78_RPORT     PINE
+#define DIO78_WPORT    PORTE
+#define DIO78_DDR    DDRE
+#define DIO78_PWM    NULL
+#define DIO79_PIN    PINE6
+#define DIO79_RPORT   PINE
+#define DIO79_WPORT    PORTE
+#define DIO79_DDR    DDRE
+#define DIO79_PWM    NULL
+#define DIO80_PIN    PINE7
+#define DIO80_RPORT   PINE
+#define DIO80_WPORT    PORTE
+#define DIO80_DDR    DDRE
+#define DIO80_PWM    NULL
+#define DIO81_PIN    PIND4
+#define DIO81_RPORT   PIND
+#define DIO81_WPORT    PORTD
+#define DIO81_DDR    DDRD
+#define DIO81_PWM    NULL
+
 #endif // MOTHERBOARD == 12
 
 

--- a/Repetier/pins.h
+++ b/Repetier/pins.h
@@ -1321,7 +1321,7 @@ STEPPER_CURRENT_CONTROL
 #define HEATER_0_PIN   9
 #define TEMP_0_PIN     0
 
-#define HEATER_1_PIN   7
+#define HEATER_1_PIN   -1 //7
 #define TEMP_1_PIN     1
 
 #define HEATER_2_PIN   -1
@@ -1347,7 +1347,7 @@ STEPPER_CURRENT_CONTROL
 #define LED_PIN        13
 #define FAN_PIN        8
 #define PS_ON_PIN      4
-#define KILL_PIN       -1
+#define KILL_PIN       80
 #define SUICIDE_PIN    -1  //PIN that has to be turned on right after start, to keep power flowing.
 
 #define E0_PINS E0_STEP_PIN,E0_DIR_PIN,E0_ENABLE_PIN,E0_MS1_PIN,E0_MS2_PIN,


### PR DESCRIPTION
Fixed fastio.h and pins.h files to work with RAMBo and RRD LCD's.   fastio.h did not have all the pins mapped that the RAMBo board uses, such as pins 70 thru 94, which are needed to use the reprapdiscount LCD etc...    Added kill pin def etc... to rambo pins.h section as well
