### PR TITLE
Fixed missing code for generic thermistor tables.

### DIFF
--- a/src/ArduinoAVR/Repetier/Extruder.cpp
+++ b/src/ArduinoAVR/Repetier/Extruder.cpp
@@ -680,6 +680,7 @@ void TemperatureController::updateCurrentTemperature()
         short oldraw = temptable[0];
         short oldtemp = temptable[1];
         short newraw,newtemp;
+        currentTemperature = (1023<<(2-ANALOG_REDUCE_BITS))-currentTemperature;
         while(i<GENERIC_THERM_NUM_ENTRIES*2)
         {
             newraw = temptable[i++];


### PR DESCRIPTION
Some code appears to have gone missing in a rewrite, causing generic thermistor table lookups to return incorrect values. Tested on my Rostock MAX, where everything now seems to be back to normal.
