### PR TITLE
Integrated support for MAX31855 thermocouple board.

### DIFF
--- a/Repetier/Configuration.h
+++ b/Repetier/Configuration.h
@@ -179,7 +179,8 @@ the wrong direction change INVERT_X_DIR or INVERT_Y_DIR.
 // 99 Generic thermistor table 3
 // 100 is AD595
 // 101 is MAX6675
-#define EXT0_TEMPSENSOR_TYPE 1
+// 102 is MAX31855
+#define EXT0_TEMPSENSOR_TYPE 101
 // Analog input pin for reading temperatures or pin enabling SS for MAX6675
 #define EXT0_TEMPSENSOR_PIN TEMP_0_PIN
 // WHich pin enables the heater
@@ -289,6 +290,7 @@ The codes are only executed for multiple extruder when changing the extruder. */
 // 99 Generic thermistor table 3
 // 100 is AD595
 // 101 is MAX6675
+// 102 is MAX31855
 #define EXT1_TEMPSENSOR_TYPE 3
 // Analog input pin for reading temperatures or pin enabling SS for MAX6675
 #define EXT1_TEMPSENSOR_PIN TEMP_2_PIN 
@@ -503,6 +505,9 @@ Value is used for all generic tables created. */
 
 // uncomment the following line for MAX6675 support.
 //#define SUPPORT_MAX6675
+
+// uncomment the following line for MAX31855 support.
+#define SUPPORT_MAX31855
 
 // ############# Heated bed configuration ########################
 

--- a/Repetier/Repetier.pde
+++ b/Repetier/Repetier.pde
@@ -143,7 +143,7 @@ Custom M Codes
 // ####################################################################################
 // #          No configuration below this line - just some errorchecking              #
 // ####################################################################################
-#ifdef SUPPORT_MAX6675
+#if defined(SUPPORT_MAX6675) || defined(SUPPORT_MAX31855)
 #if !defined SCK_PIN || !defined MOSI_PIN || !defined MISO_PIN
 #error For MAX6675 support, you need to define SCK_PIN, MISO_PIN and MOSI_PIN in pins.h
 #endif

--- a/Repetier/pins.h
+++ b/Repetier/pins.h
@@ -413,7 +413,6 @@ STEPPER_CURRENT_CONTROL
 #define SCK_PIN          52
 #define MISO_PIN         50
 #define MOSI_PIN         51
-#define MAX6675_SS       53
 
 #ifdef AZTEEG_X3
 #define SDSUPPORT true
@@ -1082,7 +1081,6 @@ STEPPER_CURRENT_CONTROL
 #define SCK_PIN          52	// PINB.1, 20, SCK
 #define MISO_PIN         50	// PINB.3, 22, MISO
 #define MOSI_PIN         51	// PINB.2, 21, MOSI
-#define MAX6675_SS       53	// PINB.0, 19, SS
 
 #endif // MOTHERBOARD == 12
 
@@ -1356,7 +1354,6 @@ STEPPER_CURRENT_CONTROL
 #define SCK_PIN          52
 #define MISO_PIN         50
 #define MOSI_PIN         51
-#define MAX6675_SS       53
 #define STEPPER_CURRENT_CONTROL CURRENT_CONTROL_DIGIPOT
 
 #endif


### PR DESCRIPTION
Possibly fixed support for MAX6675 thermocouple board.

Initialization lists are still broken if you have multiple heaters and a mix of thermocouples / thermistors.
If you need this set up currently, put the thermistor heaters before the thermocouple heaters.
