### PR TITLE
Fixed compiler error when PS_ON_PIN is disabled

### DIFF
--- a/src/ArduinoAVR/Repetier/ui.cpp
+++ b/src/ArduinoAVR/Repetier/ui.cpp
@@ -2412,9 +2412,11 @@ void UIDisplay::executeAction(int action)
             }
             break;
         case UI_ACTION_POWER:
-            Commands::waitUntilEndOfAllMoves();
-            SET_OUTPUT(PS_ON_PIN); //GND
-            TOGGLE(PS_ON_PIN);
+			#if PS_ON_PIN>=0 // avoid compiler errors when the power supply pin is disabled
+				Commands::waitUntilEndOfAllMoves();
+				SET_OUTPUT(PS_ON_PIN); //GND
+				TOGGLE(PS_ON_PIN);
+			#endif
             break;
 #if CASE_LIGHTS_PIN > 0
         case UI_ACTION_LIGHTS_ONOFF:


### PR DESCRIPTION
When the the _PS_ON_PIN_ is disabled (i.e. defined as a negative value in pins.h e.g. there is no AUX power supply; to remove the entry from menu) the compiler throws 
`error: pasting "DIO" and "-" does not give a valid preprocessing token`
because it still checks the _SET_OUTPUT(PS_ON_PIN);_ function in ui.cpp and throws the error as the _PS_ON_PIN_ is defined as unsigned char.

Adding the _PS_ON_PIN_ evaluation in the case statement helps to avoid this problem.
