### PR TITLE
Add missing break in AD8495 handling

### DIFF
--- a/src/ArduinoAVR/Repetier/Extruder.cpp
+++ b/src/ArduinoAVR/Repetier/Extruder.cpp
@@ -682,6 +682,7 @@ void TemperatureController::updateCurrentTemperature()
     }
     case 60: // AD8495 (Delivers 5mV/degC vs the AD595's 10mV)
         currentTemperatureC = ((float)currentTemperature * 1000.0f/(1024<<(2-ANALOG_REDUCE_BITS)));
+        break;
     case 100: // AD595
         //return (int)((long)raw_temp * 500/(1024<<(2-ANALOG_REDUCE_BITS)));
         currentTemperatureC = ((float)currentTemperature * 500.0f/(1024<<(2-ANALOG_REDUCE_BITS)));


### PR DESCRIPTION
Missing break ran over into AD595 code.
Made it return half temp of real when using AD8495 as AD595 has 10mv/c vs AD8495 with 5mv/c.
Only affects users (me) of temperature sensor type 60.
