### PR TITLE
Fixing UI bug When Set New Z=0.00 in Delta printer.

### DIFF
--- a/src/ArduinoAVR/Repetier/ui.cpp
+++ b/src/ArduinoAVR/Repetier/ui.cpp
@@ -2749,6 +2749,7 @@ void UIDisplay::executeAction(int action)
             // Delta printer need change xLength and yLength after change zLength
             Printer::xLength = Printer::zLength;
             Printer::yLength = Printer::zLength;
+            Printer::updateDerivedParameter();
 #endif
             transformCartesianStepsToDeltaSteps(Printer::currentPositionSteps, Printer::currentDeltaPositionSteps);
 #endif


### PR DESCRIPTION
Currently Set New Z=0.00 in Delta printer only change zLength. This patch will update all 3 axis length to same value for Delta printer.
