### PR TITLE
Edit with atmel studio

### DIFF
--- a/src/ArduinoAVR/Repetier/Extruder.cpp
+++ b/src/ArduinoAVR/Repetier/Extruder.cpp
@@ -682,6 +682,7 @@ void TemperatureController::updateCurrentTemperature()
     }
     case 60: // AD8495 (Delivers 5mV/degC vs the AD595's 10mV)
         currentTemperatureC = ((float)currentTemperature * 1000.0f/(1024<<(2-ANALOG_REDUCE_BITS)));
+        break;
     case 100: // AD595
         //return (int)((long)raw_temp * 500/(1024<<(2-ANALOG_REDUCE_BITS)));
         currentTemperatureC = ((float)currentTemperature * 500.0f/(1024<<(2-ANALOG_REDUCE_BITS)));

--- a/src/ArduinoAVR/Repetier_atMega2560.cproj
+++ b/src/ArduinoAVR/Repetier_atMega2560.cproj
@@ -1,0 +1,284 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectVersion>6.0</ProjectVersion>
+    <ToolchainName>com.Atmel.AVRGCC8</ToolchainName>
+    <ProjectGuid>{092e2ae2-034f-445f-87ae-475ebdfa37e8}</ProjectGuid>
+    <avrdevice>ATmega2560</avrdevice>
+    <avrdeviceseries>none</avrdeviceseries>
+    <OutputType>Executable</OutputType>
+    <Language>C</Language>
+    <OutputFileName>$(MSBuildProjectName)</OutputFileName>
+    <OutputFileExtension>.elf</OutputFileExtension>
+    <OutputDirectory>$(MSBuildProjectDirectory)\$(Configuration)</OutputDirectory>
+    <AssemblyName>Repetier_avr</AssemblyName>
+    <Name>Repetier_atMega2560</Name>
+    <RootNamespace>Repetier_avr</RootNamespace>
+    <ToolchainFlavour>Native</ToolchainFlavour>
+    <KeepTimersRunning>true</KeepTimersRunning>
+    <OverrideVtor>false</OverrideVtor>
+    <OverrideVtorValue />
+    <eraseonlaunchrule>0</eraseonlaunchrule>
+    <AsfVersion>3.5.1</AsfVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <ToolchainSettings>
+      <AvrGcc>
+        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+        <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+        <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+        <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+        <avrgcc.compiler.optimization.level>Optimize for size (-Os)</avrgcc.compiler.optimization.level>
+        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+        <avrgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>m</Value>
+          </ListValues>
+        </avrgcc.linker.libraries.Libraries>
+      </AvrGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <ToolchainSettings>
+      <AvrGcc>
+        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+        <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+        <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+        <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+        <avrgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\avr\cores\arduino</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\avr\libraries\EEPROM</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\avr\libraries\SoftwareSerial</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\avr\libraries\SPI</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\avr\libraries\Wire</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\avr\variants\mega</Value>
+          </ListValues>
+        </avrgcc.compiler.directories.IncludePaths>
+        <avrgcc.compiler.optimization.level>Optimize (-O1)</avrgcc.compiler.optimization.level>
+        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+        <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
+        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+        <avrgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>m</Value>
+          </ListValues>
+        </avrgcc.linker.libraries.Libraries>
+        <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
+      </AvrGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Repetier" />
+    <Folder Include="Repetier\cores" />
+    <Folder Include="Repetier\libraries" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Repetier\Commands.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Communication.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\CDC.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\HardwareSerial.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\IPAddress.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\main.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\new.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\Print.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\Stream.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\Tone.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\USBCore.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\WMath.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\cores\WString.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Eeprom.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Extruder.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\gcode.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\HAL.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\EEPROM.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\Ethernet.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\Firmata.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\LiquidCrystal.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\OBD.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\SD.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\Servo.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\SoftwareSerial.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\SPI.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\Stepper.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\TinyGPS.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\U8gui.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\WiFi.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\libraries\Wire.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Makefile">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\motion.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Printer.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Repetier.depend">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Repetier.ino">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\SDCard.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\SdFat.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\ui.cpp">
+      <SubType>compile</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Repetier\Commands.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Communication.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Configuration.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\cores\WInterrupts.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\cores\wiring.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\cores\wiring_analog.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\cores\wiring_digital.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\cores\wiring_pulse.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\cores\wiring_shift.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Eeprom.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Extruder.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\fastio.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\FatStructs.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\gcode.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\HAL.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\libraries\twi.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\motion.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\pins.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Printer.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Repetier.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\SdFat.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\u8glib_ex.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\ui.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\uiconfig.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\uilang.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\uimenu.h">
+      <SubType>compile</SubType>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(AVRSTUDIO_EXE_PATH)\\Vs\\Compiler.targets" />
+</Project>

--- a/src/ArduinoDUE/Repetier_sam3x8E.cproj
+++ b/src/ArduinoDUE/Repetier_sam3x8E.cproj
@@ -1,0 +1,199 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectVersion>6.0</ProjectVersion>
+    <ToolchainName>com.Atmel.ARMGCC</ToolchainName>
+    <ProjectGuid>{fb8b314d-5d77-4902-80a2-cbb301b854fd}</ProjectGuid>
+    <avrdevice>ATSAM3X8E</avrdevice>
+    <avrdeviceseries>none</avrdeviceseries>
+    <OutputType>Executable</OutputType>
+    <Language>C</Language>
+    <OutputFileName>$(MSBuildProjectName)</OutputFileName>
+    <OutputFileExtension>.elf</OutputFileExtension>
+    <OutputDirectory>$(MSBuildProjectDirectory)\$(Configuration)</OutputDirectory>
+    <AssemblyName>Repetier_sam</AssemblyName>
+    <Name>Repetier_sam3x8E</Name>
+    <RootNamespace>Repetier_sam</RootNamespace>
+    <ToolchainFlavour>Native</ToolchainFlavour>
+    <AsfVersion>3.5.1</AsfVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <ToolchainSettings>
+      <ArmGcc>
+        <armgcc.common.general.symbols>__SAM3X8E__</armgcc.common.general.symbols>
+        <armgcc.common.outputfiles.hex>True</armgcc.common.outputfiles.hex>
+        <armgcc.common.outputfiles.lss>True</armgcc.common.outputfiles.lss>
+        <armgcc.common.outputfiles.eep>True</armgcc.common.outputfiles.eep>
+        <armgcc.common.outputfiles.bin>True</armgcc.common.outputfiles.bin>
+        <armgcc.common.outputfiles.srec>True</armgcc.common.outputfiles.srec>
+        <armgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>C:\Program Files (x86)\Atmel\Atmel Studio 6.0\extensions\Atmel\ARMGCC\3.3.1.128\ARMSupportFiles</Value>
+            <Value>C:\Program Files (x86)\Atmel\Atmel Studio 6.0\extensions\Atmel\ARMGCC\3.3.1.128\ARMSupportFiles\CMSIS\Include</Value>
+            <Value>C:\Program Files (x86)\Atmel\Atmel Studio 6.0\extensions\Atmel\ARMGCC\3.3.1.128\ARMSupportFiles\Device\ATMEL</Value>
+            <Value>C:\Program Files (x86)\Atmel\Atmel Studio 6.0\extensions\Atmel\ARMGCC\3.3.1.128\ARMSupportFiles\Device\ATMEL\sam3xa\include</Value>
+          </ListValues>
+        </armgcc.compiler.directories.IncludePaths>
+        <armgcc.compiler.optimization.level>Optimize for size (-Os)</armgcc.compiler.optimization.level>
+        <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
+        <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
+        <armgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>m</Value>
+          </ListValues>
+        </armgcc.linker.libraries.Libraries>
+        <armgcc.linker.libraries.LibrarySearchPaths>
+          <ListValues>
+            <Value>../cmsis/linkerScripts</Value>
+          </ListValues>
+        </armgcc.linker.libraries.LibrarySearchPaths>
+        <armgcc.linker.optimization.GarbageCollectUnusedSections>True</armgcc.linker.optimization.GarbageCollectUnusedSections>
+        <armgcc.linker.miscellaneous.LinkerFlags>-Tsam3x8e_flash.ld</armgcc.linker.miscellaneous.LinkerFlags>
+      </ArmGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <ToolchainSettings>
+      <ArmGcc>
+        <armgcc.common.general.symbols>__SAM3X8E__</armgcc.common.general.symbols>
+        <armgcc.common.outputfiles.hex>True</armgcc.common.outputfiles.hex>
+        <armgcc.common.outputfiles.lss>True</armgcc.common.outputfiles.lss>
+        <armgcc.common.outputfiles.eep>True</armgcc.common.outputfiles.eep>
+        <armgcc.common.outputfiles.bin>True</armgcc.common.outputfiles.bin>
+        <armgcc.common.outputfiles.srec>True</armgcc.common.outputfiles.srec>
+        <armgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\sam\cores\arduino</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\sam\cores\arduino\avr</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\sam\cores\arduino\USB</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\sam\libraries\SPI</Value>
+            <Value>C:\Program Files (x86)\Arduino\hardware\arduino\sam\libraries\Wire</Value>
+          </ListValues>
+        </armgcc.compiler.directories.IncludePaths>
+        <armgcc.compiler.optimization.level>Optimize (-O1)</armgcc.compiler.optimization.level>
+        <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
+        <armgcc.compiler.optimization.DebugLevel>Maximum (-g3)</armgcc.compiler.optimization.DebugLevel>
+        <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
+        <armgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>m</Value>
+          </ListValues>
+        </armgcc.linker.libraries.Libraries>
+        <armgcc.linker.libraries.LibrarySearchPaths>
+          <ListValues>
+            <Value>../cmsis/linkerScripts</Value>
+          </ListValues>
+        </armgcc.linker.libraries.LibrarySearchPaths>
+        <armgcc.linker.optimization.GarbageCollectUnusedSections>True</armgcc.linker.optimization.GarbageCollectUnusedSections>
+        <armgcc.linker.miscellaneous.LinkerFlags>-Tsam3x8e_flash.ld</armgcc.linker.miscellaneous.LinkerFlags>
+        <armgcc.assembler.debugging.DebugLevel>Default (-g)</armgcc.assembler.debugging.DebugLevel>
+        <armgcc.preprocessingassembler.debugging.DebugLevel>Default (-Wa,-g)</armgcc.preprocessingassembler.debugging.DebugLevel>
+      </ArmGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Repetier" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Repetier\Commands.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Communication.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Eeprom.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Extruder.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\gcode.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\HAL.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Makefile">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\motion.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Printer.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\Repetier.ino">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\SDCard.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\SdFat.cpp">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Repetier\ui.cpp">
+      <SubType>compile</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Repetier\Commands.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Communication.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Configuration.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Eeprom.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Extruder.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\fastio.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\FatStructs.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\gcode.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\HAL.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\motion.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\pins.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Printer.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\Repetier.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\SdFat.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\u8glib_ex.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\ui.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\uiconfig.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\uilang.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Repetier\uimenu.h">
+      <SubType>compile</SubType>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(AVRSTUDIO_EXE_PATH)\\Vs\\Compiler.targets" />
+</Project>

--- a/src/Edit_in_Atmel_Studio.atsln
+++ b/src/Edit_in_Atmel_Studio.atsln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Atmel Studio Solution File, Format Version 11.00
+Project("{54F91283-7BC4-4236-8FF9-10F437C3AD48}") = "Repetier_atMega2560", "ArduinoAVR\Repetier_atMega2560.cproj", "{092E2AE2-034F-445F-87AE-475EBDFA37E8}"
+EndProject
+Project("{54F91283-7BC4-4236-8FF9-10F437C3AD48}") = "Repetier_sam3x8E", "ArduinoDUE\Repetier_sam3x8E.cproj", "{FB8B314D-5D77-4902-80A2-CBB301B854FD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Debug|AVR = Debug|AVR
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Release|ARM = Release|ARM
+		Release|AVR = Release|AVR
+		Release|Mixed Platforms = Release|Mixed Platforms
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Debug|ARM.ActiveCfg = Debug|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Debug|AVR.ActiveCfg = Debug|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Debug|AVR.Build.0 = Debug|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Debug|Mixed Platforms.ActiveCfg = Debug|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Debug|Mixed Platforms.Build.0 = Debug|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Release|ARM.ActiveCfg = Release|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Release|AVR.ActiveCfg = Release|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Release|AVR.Build.0 = Release|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Release|Mixed Platforms.ActiveCfg = Release|AVR
+		{092E2AE2-034F-445F-87AE-475EBDFA37E8}.Release|Mixed Platforms.Build.0 = Release|AVR
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Debug|ARM.ActiveCfg = Debug|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Debug|ARM.Build.0 = Debug|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Debug|AVR.ActiveCfg = Debug|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Debug|Mixed Platforms.ActiveCfg = Debug|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Debug|Mixed Platforms.Build.0 = Debug|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Release|ARM.ActiveCfg = Release|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Release|ARM.Build.0 = Release|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Release|AVR.ActiveCfg = Release|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Release|Mixed Platforms.ActiveCfg = Release|ARM
+		{FB8B314D-5D77-4902-80A2-CBB301B854FD}.Release|Mixed Platforms.Build.0 = Release|ARM
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Added example project files for Atmel Studio with examples of paths to libraries for Arduino included in the projects.

The SD8495 and the AD595 can not share code and it was a bug in earlier code that made it appear so.
Missing break was in the old branch.
