### PR TITLE
Update HAL.h , fix startwatchdog() for Due

### DIFF
--- a/src/ArduinoDUE/Repetier/HAL.h
+++ b/src/ArduinoDUE/Repetier/HAL.h
@@ -595,7 +595,7 @@ public:
 
 
     // Watchdog support
-    inline static void startWatchdog() { WDT_Enable(WDT, WDT_MR_WDRSTEN | WATCHDOG_INTERVAL );};
+    inline static void startWatchdog() { WDT_Enable(WDT, (WATCHDOG_INTERVAL<<16 ) | WDT_MR_WDRSTEN | WATCHDOG_INTERVAL );};
     inline static void stopWatchdog() {}
     inline static void pingWatchdog() {WDT_Restart(WDT);};
 


### PR DESCRIPTION
Reference: http://www.atmel.com/images/doc11057.pdf , page 272
To enable wathdog in Due in WT_MR register we need both
WDD: Watchdog Delta Value &  WDV: Watchdog Counter Value
WDV is WATCHDOG_INTERVAL. To simplify the setup WDD value should same as WATCHDOG_INTERVAL
But in startwatchdog() WDD is not included in setup. This will cause the Due board to reset it self due to the error in watchdog reset.
Adding WATCHDOG_INTERVAL<<16 in startWatchdog() will fix this issue.