### PR TITLE
Additional fastio.h pins for Alligator board

### DIFF
--- a/src/ArduinoDUE/Repetier/fastio.h
+++ b/src/ArduinoDUE/Repetier/fastio.h
@@ -270,6 +270,37 @@
 #define DIO91_PORT PIOB
 #define DIO91_PIN PIO_PB15A_CANRX1|PIO_PB14A_CANTX1
 
+// Additional Pins for Alligator board
+#if (MOTHERBOARD == 500) || (MOTHERBOARD == 501)
+//92
+#define DIO92_PORT PIOA
+#define DIO92_PIN PIO_PA5
+//93
+#define DIO93_PORT PIOB
+#define DIO93_PIN PIO_PB12X1_AD8
+//94
+#define DIO94_PORT PIOB
+#define DIO94_PIN PIO_PB22
+//95
+#define DIO95_PORT PIOB
+#define DIO95_PIN PIO_PB23
+//96
+#define DIO96_PORT PIOB
+#define DIO96_PIN PIO_PB24
+//97
+#define DIO97_PORT PIOC
+#define DIO97_PIN PIO_PC20
+//98
+#define DIO98_PORT PIOC
+#define DIO98_PIN PIO_PC27
+//99
+#define DIO99_PORT PIOC
+#define DIO99_PIN PIO_PC10
+//100
+#define DIO100_PORT PIOC
+#define DIO100_PIN PIO_PC11
+#endif
+
 
 
 


### PR DESCRIPTION
Hi Roland,

Alligator uses more pins than ArduinoDUE, I mapped these pin (PIN-92-100) in Fastio.h to resolve compile errors with Alligator board.

Thanks 