### PR TITLE
Add MCP4728 DAC (Digital Trimpot) support for PrintrBoard Rev. F

### DIFF
--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -416,6 +416,129 @@ void motorCurrentControlInit() //Initialize Motor Current
 }
 #endif
 
+
+#if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
+uint8_t   _intVref[]     = {MCP4728_VREF, MCP4728_VREF, MCP4728_VREF, MCP4728_VREF};
+uint8_t   _gain[]        = {MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN};
+uint8_t   _powerDown[]   = {0,0,0,0};
+int16_t   dac_motor_current[] =  {0,0,0,0};
+
+uint8_t   _intVrefEp[]   = {MCP4728_VREF, MCP4728_VREF, MCP4728_VREF, MCP4728_VREF};
+uint8_t   _gainEp[]      = {MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN};
+uint8_t   _powerDownEp[] = {0,0,0,0};
+int16_t    _valuesEp[]   = {0,0,0,0};
+
+uint8_t   dac_stepper_channel[] = MCP4728_STEPPER_ORDER;
+
+int dacSimpleCommand(uint8_t simple_command) {
+    HAL::i2cStartWait(MCP4728_GENERALCALL_ADDRESS + I2C_WRITE);
+    HAL::i2cWrite(simple_command);
+    HAL::i2cStop();
+}
+
+void dacReadStatus() {
+  HAL::delayMilliseconds(500);
+  HAL::i2cStartWait(MCP4728_I2C_ADDRESS | I2C_READ);
+
+  for (int i=0;i<8;i++) { // 2 sets of 4 Channels (1 EEPROM, 1 Runtime)
+    uint8_t deviceID = HAL::i2cReadAck();
+    uint8_t  hiByte  = HAL::i2cReadAck();
+    uint8_t  loByte  = ((i < 7) ? HAL::i2cReadAck() : HAL::i2cReadNak());
+
+    uint8_t isEEPROM = (deviceID & 0B00001000) >> 3;
+    uint8_t channel  = (deviceID & 0B00110000) >> 4;
+    if (isEEPROM == 1) {
+      _intVrefEp[channel] = (hiByte & 0B10000000) >> 7;
+      _gainEp[channel] = (hiByte & 0B00010000) >> 4;
+      _powerDownEp[channel] = (hiByte & 0B01100000) >> 5;
+      _valuesEp[channel] = word((hiByte & 0B00001111), loByte);
+    } else {
+      _intVref[channel] = (hiByte & 0B10000000) >> 7;
+      _gain[channel] = (hiByte & 0B00010000) >> 4;
+      _powerDown[channel] = (hiByte & 0B01100000) >> 5;
+      dac_motor_current[channel] = word((hiByte & 0B00001111), loByte);
+    }
+  }
+
+  HAL::i2cStop();
+}
+
+void dacAnalogUpdate(bool saveEEPROM = false) {
+  uint8_t dac_write_cmd = MCP4728_CMD_SEQ_WRITE;
+
+  HAL::i2cStartWait(MCP4728_I2C_ADDRESS + I2C_WRITE);
+  if (saveEEPROM) HAL::i2cWrite(dac_write_cmd);
+
+  for (int i=0;i<MCP4728_NUM_CHANNELS;i++){
+    uint16_t level = dac_motor_current[i];
+      
+    uint8_t highbyte = ( _intVref[i] << 7 | _gain[i] << 4 | (uint8_t)((level) >> 8) );
+    uint8_t lowbyte =  ( (uint8_t) ((level) & 0xff) );
+    dac_write_cmd = MCP4728_CMD_MULTI_WRITE | (i << 1);
+
+    if (!saveEEPROM) HAL::i2cWrite(dac_write_cmd);
+    HAL::i2cWrite(highbyte);
+    HAL::i2cWrite(lowbyte);
+  }
+
+  HAL::i2cStop();
+
+  // Instruct the MCP4728 to reflect our updated value(s) on its DAC Outputs
+  dacSimpleCommand((uint8_t)MCP4728_CMD_GC_UPDATE); // MCP4728 General Command Software Update (Update all DAC Outputs to reflect settings)
+
+  // if (saveEEPROM) dacReadStatus(); // Not necessary, just a read-back sanity check.
+}
+
+void dacCommitEeprom() {
+  dacAnalogUpdate(true);
+  dacReadStatus(); // Refresh EEPROM Values with values actually stored in EEPROM. .
+}
+
+void dacPrintSet(int dacChannelSettings[], const char* dacChannelPrefixes[]){
+  for (int i=0;i<MCP4728_NUM_CHANNELS;i++){
+    uint8_t dac_channel = dac_stepper_channel[i]; // DAC Channel is a mapped lookup.
+    Com::printF(dacChannelPrefixes[i], ((float)dacChannelSettings[dac_channel] *100 / MCP4728_VOUT_MAX));
+    Com::printF(Com::tSpaceRaw);
+    Com::printFLN(Com::tColon,dacChannelSettings[dac_channel]);
+  }
+}
+
+void dacPrintValues() {
+  const char* dacChannelPrefixes[] = {Com::tSpaceXColon,Com::tSpaceYColon,Com::tSpaceZColon,Com::tSpaceEColon};
+
+  Com::printFLN(Com::tMCPEpromSettings);
+  dacPrintSet(_valuesEp, dacChannelPrefixes); // Once for the EEPROM set
+
+  Com::printFLN(Com::tMCPCurrentSettings);
+  dacPrintSet(dac_motor_current, dacChannelPrefixes); // And another for the RUNTIME set
+}
+
+void setMotorCurrent( uint8_t xyz_channel, uint16_t level )
+{
+    if ((xyz_channel<0) || (xyz_channel >= MCP4728_NUM_CHANNELS)) return;
+    uint8_t stepper_channel = dac_stepper_channel[xyz_channel];
+    dac_motor_current[stepper_channel] = level;
+    dacAnalogUpdate();
+}
+
+void setMotorCurrentPercent( uint8_t channel, float level)
+{
+  uint16_t raw_level = ( level * MCP4728_VOUT_MAX / 100 );
+  setMotorCurrent(channel,raw_level);
+}
+
+void motorCurrentControlInit() //Initialize MCP4728 Motor Current
+{
+    HAL::i2cInit(400000); // Initialize the i2c bus.
+    dacSimpleCommand((uint8_t)MCP4728_CMD_GC_RESET); // MCP4728 General Command Reset
+    dacReadStatus(); // Load Values from EEPROM.
+
+    for(int i=0; i< MCP4728_NUM_CHANNELS; i++) {
+        setMotorCurrent(dac_stepper_channel[i], _valuesEp[i] ); // This is not strictly necessary, but serves as a good sanity check to ensure we're all on the same page.
+    }
+}
+#endif
+
 #if defined(X_MS1_PIN) && X_MS1_PIN > -1
 void microstepMS(uint8_t driver, int8_t ms1, int8_t ms2)
 {
@@ -1953,6 +2076,23 @@ void Commands::processMCode(GCode *com)
     case 603:
         Printer::setInterruptEvent(PRINTER_INTERRUPT_EVENT_JAM_DETECTED, true);
         break;
+    case 907: // M907 Set digital trimpot/DAC motor current using axis codes.
+        {
+        #if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
+           // If "S" is specified, use that as initial default value, then update each axis w/ specific values as found later.
+           if(com->hasS()) {
+             for(int i=0;i < MCP4728_NUM_CHANNELS;i++) {
+               setMotorCurrentPercent(i, com->S);
+             }
+           }
+
+           if(com->hasX()) setMotorCurrentPercent(0, (float)com->X);
+           if(com->hasY()) setMotorCurrentPercent(1, (float)com->Y);
+           if(com->hasZ()) setMotorCurrentPercent(2, (float)com->Z);
+           if(com->hasE()) setMotorCurrentPercent(3, (float)com->E);
+        #endif
+        }
+        break;
     case 908: // M908 Control digital trimpot directly.
     {
 #if STEPPER_CURRENT_CONTROL != CURRENT_CONTROL_MANUAL
@@ -1961,6 +2101,18 @@ void Commands::processMCode(GCode *com)
             setMotorCurrent((uint8_t)com->P, (unsigned int)com->S);
 #endif
     }
+    break;
+    case 909: // M909 Read digital trimpot settings.
+    {
+#if STEPPER_CURRENT_CONTROL != CURRENT_CONTROL_MANUAL
+    dacPrintValues();
+#endif
+    }
+    break;
+    case 910: // M910 - Commit digipot/DAC value to external EEPROM
+#if STEPPER_CURRENT_CONTROL != CURRENT_CONTROL_MANUAL
+    dacCommitEeprom();
+#endif
     break;
     default:
         if(Printer::debugErrors())

--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -2104,13 +2104,13 @@ void Commands::processMCode(GCode *com)
     break;
     case 909: // M909 Read digital trimpot settings.
     {
-#if STEPPER_CURRENT_CONTROL != CURRENT_CONTROL_MANUAL
+#if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
     dacPrintValues();
 #endif
     }
     break;
     case 910: // M910 - Commit digipot/DAC value to external EEPROM
-#if STEPPER_CURRENT_CONTROL != CURRENT_CONTROL_MANUAL
+#if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
     dacCommitEeprom();
 #endif
     break;

--- a/src/ArduinoAVR/Repetier/Communication.cpp
+++ b/src/ArduinoAVR/Repetier/Communication.cpp
@@ -393,6 +393,11 @@ FSTRINGVALUE(Com::tEPRRetractionUndoSpeed,"Retraction undo speed")
 FSTRINGVALUE(Com::tConfig,"Config:")
 FSTRINGVALUE(Com::tExtrDot,"Extr.")
 
+#if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
+FSTRINGVALUE(Com::tMCPEpromSettings,  "MCP4728 DAC EEPROM Settings:")
+FSTRINGVALUE(Com::tMCPCurrentSettings,"MCP4728 DAC Current Settings:")
+#endif
+
 void Com::config(FSTRINGPARAM(text)) {
     printF(tConfig);
     printFLN(text);

--- a/src/ArduinoAVR/Repetier/Communication.h
+++ b/src/ArduinoAVR/Repetier/Communication.h
@@ -378,6 +378,11 @@ FSTRINGVAR(tEPRRetractionUndoSpeed)
 FSTRINGVAR(tConfig)
 FSTRINGVAR(tExtrDot)
 
+#if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
+FSTRINGVAR(tMCPEpromSettings)
+FSTRINGVAR(tMCPCurrentSettings)
+#endif
+
 static void config(FSTRINGPARAM(text));
 static void config(FSTRINGPARAM(text),int value);
 static void config(FSTRINGPARAM(text),const char *msg);

--- a/src/ArduinoAVR/Repetier/Configuration.h
+++ b/src/ArduinoAVR/Repetier/Configuration.h
@@ -71,6 +71,7 @@ setpe per mm and heater manager settings in extruder 0 are used! */
 // Sethi 3D_1                 = 72
 // Teensylu (at90usb)         = 8 // requires Teensyduino
 // Printrboard (at90usb)      = 9 // requires Teensyduino
+// Printrboard (at90usb) RevF = 92 // requires Teensyduino
 // Foltyn 3D Master           = 12
 // MegaTronics 1.0            = 70
 // Megatronics 2.0            = 701

--- a/src/ArduinoAVR/Repetier/HAL.h
+++ b/src/ArduinoAVR/Repetier/HAL.h
@@ -61,7 +61,7 @@ All known arduino boards use 64. This value is needed for the extruder timing. *
 
 #define ANALOG_PRESCALER _BV(ADPS0)|_BV(ADPS1)|_BV(ADPS2)
 
-#if MOTHERBOARD==8 || MOTHERBOARD==88 || MOTHERBOARD==9 || CPU_ARCH!=ARCH_AVR
+#if MOTHERBOARD==8 || MOTHERBOARD==88 || MOTHERBOARD==9 || MOTHERBOARD==92 || CPU_ARCH!=ARCH_AVR
 #define EXTERNALSERIAL
 #endif
 //#define EXTERNALSERIAL  // Force using arduino serial

--- a/src/ArduinoAVR/Repetier/pins.h
+++ b/src/ArduinoAVR/Repetier/pins.h
@@ -23,6 +23,7 @@ STEPPER_CURRENT_CONTROL
 #define CURRENT_CONTROL_DIGIPOT 2  // Use a digipot like RAMBO does
 #define CURRENT_CONTROL_LTC2600 3  // Use LTC2600 like Foltyn 3D Master
 #define CURRENT_CONTROL_ALLIGATOR 4  //Use External DAC like Alligator
+#define CURRENT_CONTROL_MCP4728 5  // Use an i2c DAC as a digipot like PrintrBoard Rev. F
 
 /****************************************************************************************
 * Arduino pin assignment
@@ -1342,6 +1343,85 @@ STEPPER_CURRENT_CONTROL
 #endif
 
 #endif
+
+/****************************************************************************************
+* Printrboard Rev. F pin assingments (ATMEGA90USB1286)
+* Requires the Teensyduino software with Teensy2.0++ selected in arduino IDE!
+* See http://reprap.org/wiki/Printrboard for more info
+*
+* Rev. F uses an MCP4728 DAC to generate the Reference Voltage used to determine the
+* Stepper Driver's maximum current.
+*
+* On PrintrBoard, with Sense Resistors = 0.11 Ohms, and 2 Amps maximum current rating,
+* the Maximum VRef to send is calculated as:
+* 
+*   2.00 Amps Maximum Output * (8 * 0.11 Ohms) = 1.76 Maximum VRef from MCP4728.
+*
+****************************************************************************************/
+#if MOTHERBOARD == 92
+#define KNOWN_BOARD 1
+
+// Definition for current control
+#define STEPPER_CURRENT_CONTROL   CURRENT_CONTROL_MCP4728
+
+#define MCP4728_I2C_ADDRESS	0x60 << 1 // Base Address (0x60); Pre-Shifted Left 1 bit for Repetier HAL.
+#define MCP4728_GENERALCALL_ADDRESS  0x00 // General Call Address. Weird, but OK...
+#define MCP4728_CMD_MULTI_WRITE   0B01000000 // Writes DAC Settings, Does not update EEPROM.
+#define MCP4728_CMD_SEQ_WRITE     0B01010000 // Writes DAC Settings, also persists to EEPROM.
+#define MCP4728_CMD_GC_UPDATE     0B00001000 // General Call Update - Update all DAC Outputs (Only way to update DAC Outputs on PrintrBoard Rev F because they tied /LDAC to VDD.
+#define MCP4728_CMD_GC_RESET      0B00000110 // General Call Reset
+#define MCP4728_VREF 		1 // From DataSheet. We will use MCP4728's internal 2.048V as Vref
+#define MCP4728_GAIN		0 // From DataSheet. Use 1x Gain Multiplier (0V - 2.048V); 
+#define MCP4728_NUM_CHANNELS    4 // Duh. Specified here in case there's a beefier chip used on some other board someday.
+#define MCP4728_STEPPER_ORDER 	{3,2,1,0} // PrintrBoard wired 'em up backwards. SMH.  X, Y, Z, E
+#define MCP4728_VOUT_MAX	3520 // 1.76 Volts * 2000. See DataSheets for the math. Value should be between 0-4095
+
+#define ORIG_X_STEP_PIN         28
+#define ORIG_X_DIR_PIN          29
+#define ORIG_X_ENABLE_PIN       19
+#define ORIG_X_MIN_PIN          47
+#define ORIG_X_MAX_PIN          -1
+
+#define ORIG_Y_STEP_PIN         30
+#define ORIG_Y_DIR_PIN          31
+#define ORIG_Y_ENABLE_PIN       18
+#define ORIG_Y_MIN_PIN          24 // (Was Pin 20 on Rev B-E); Don't use this if you want to use SD card. Use 37 and put the endstop in the e-stop slot!!!
+#define ORIG_Y_MAX_PIN          -1
+
+#define ORIG_Z_STEP_PIN         32
+#define ORIG_Z_DIR_PIN          33
+#define ORIG_Z_ENABLE_PIN       17
+#define ORIG_Z_MIN_PIN          36
+#define ORIG_Z_MAX_PIN          -1
+
+#define ORIG_E0_STEP_PIN         34
+#define ORIG_E0_DIR_PIN          35
+#define ORIG_E0_ENABLE_PIN       13
+#define TEMP_0_PIN          1 // Extruder - ANALOG PIN NUMBER!
+#define TEMP_1_PIN          0 // Bed - ANALOG PIN NUMBER!
+#define HEATER_0_PIN       15 // Extruder
+#define HEATER_1_PIN       14 // bed
+#define HEATER_2_PIN   -1
+#define TEMP_2_PIN     -1
+
+#define SDPOWER            -1
+#define SDSS               20 // (Was Pin 26 on Rev. B-E);  old value 2
+#define LED_PIN            -1
+
+#define ORIG_FAN_PIN            16 // Fan
+#define ORIG_PS_ON_PIN          -1
+
+#define E0_PINS ORIG_E0_STEP_PIN,ORIG_E0_DIR_PIN,ORIG_E0_ENABLE_PIN,
+#define E1_PINS
+#if !SDSUPPORT
+// these pins are defined in the SD library if building with SD support
+#define SCK_PIN          21
+#define MISO_PIN         23
+#define MOSI_PIN         22
+#endif
+
+#endif
+
 
 /****************************************************************************************
 * Printrboard Rev. B pin assingments (ATMEGA90USB1286)


### PR DESCRIPTION
Creates a new motherboard type (92) for the PrintrBoard Rev. F., which uses an MCP4728 DAC as a digital trimpot. 

Implements additional M-codes as PrintrBot's fork of Marlin does. (M907, M908, M909, and M910) - PrintrBot's fork of Marlin was used as a guide or reference implementation.