### PR TITLE
WIP: Allow homing of dual Y steppers individually

### DIFF
--- a/src/ArduinoAVR/Repetier/HAL.h
+++ b/src/ArduinoAVR/Repetier/HAL.h
@@ -143,6 +143,7 @@ typedef uint16_t speed_t;
 typedef uint32_t ticks_t;
 typedef uint32_t millis_t;
 typedef uint8_t flag8_t;
+typedef uint16_t flag16_t;
 typedef int8_t fast8_t;
 typedef uint8_t ufast8_t;
 

--- a/src/ArduinoAVR/Repetier/Printer.cpp
+++ b/src/ArduinoAVR/Repetier/Printer.cpp
@@ -159,11 +159,11 @@ int debugWaitLoop = 0;
 fast8_t Printer::wizardStackPos;
 wizardVar Printer::wizardStack[WIZARD_STACK_SIZE];
 
-flag8_t Endstops::lastState = 0;
-flag8_t Endstops::lastRead = 0;
+endstops_t Endstops::lastState = 0;
+endstops_t Endstops::lastRead = 0;
 
 void Endstops::update() {
-    flag8_t newRead = 0;
+    endstops_t newRead = 0;
 #if (X_MIN_PIN > -1) && MIN_HARDWARE_ENDSTOP_X
         if(READ(X_MIN_PIN) != ENDSTOP_X_MIN_INVERTING)
             newRead |= ENDSTOP_X_MIN_ID;
@@ -175,6 +175,10 @@ void Endstops::update() {
 #if (Y_MIN_PIN > -1) && MIN_HARDWARE_ENDSTOP_Y
         if(READ(Y_MIN_PIN) != ENDSTOP_Y_MIN_INVERTING)
             newRead |= ENDSTOP_Y_MIN_ID;
+#endif
+#if (Y2_MIN_PIN > -1) && MIN_HARDWARE_ENDSTOP_Y2
+        if(READ(Y2_MIN_PIN) != ENDSTOP_Y2_MIN_INVERTING)
+            newRead |= ENDSTOP_Y2_MIN_ID;
 #endif
 #if (Y_MAX_PIN > -1) && MAX_HARDWARE_ENDSTOP_Y
         if(READ(Y_MAX_PIN) != ENDSTOP_Y_MAX_INVERTING)
@@ -777,6 +781,16 @@ void Printer::setup()
 #endif
 #else
 #error You have defined hardware y min endstop without pin assignment. Set pin number for Y_MIN_PIN
+#endif
+#endif
+#if MIN_HARDWARE_ENDSTOP_Y2
+#if Y2_MIN_PIN > -1
+    SET_INPUT(Y2_MIN_PIN);
+#if ENDSTOP_PULLUP_Y2_MIN
+    PULLUP(Y2_MIN_PIN, HIGH);
+#endif
+#else
+#error You have defined hardware y2 min endstop without pin assignment. Set pin number for Y2_MIN_PIN
 #endif
 #endif
 #if MIN_HARDWARE_ENDSTOP_Z

--- a/src/ArduinoAVR/Repetier/Printer.h
+++ b/src/ArduinoAVR/Repetier/Printer.h
@@ -42,6 +42,8 @@ Level 5: Nonlinear motor step position, only for nonlinear drive systems
 #ifndef PRINTER_H_INCLUDED
 #define PRINTER_H_INCLUDED
 
+typedef flag16_t endstops_t;
+
 union floatLong
 {
     float f;
@@ -148,6 +150,7 @@ private:
 #define ENDSTOP_X_MIN_ID 1
 #define ENDSTOP_X_MAX_ID 2
 #define ENDSTOP_Y_MIN_ID 4
+#define ENDSTOP_Y2_MIN_ID 256
 #define ENDSTOP_Y_MAX_ID 8
 #define ENDSTOP_Z_MIN_ID 16
 #define ENDSTOP_Z_MAX_ID 32
@@ -155,8 +158,8 @@ private:
 #define ENDSTOP_Z_PROBE_ID 128
 
 class Endstops {
-    static flag8_t lastState;
-    static flag8_t lastRead;
+    static endstops_t lastState;
+    static endstops_t lastRead;
 public:
     static void update();
     static void report();
@@ -180,6 +183,13 @@ public:
     static INLINE bool yMin() {
 #if (Y_MIN_PIN > -1) && MIN_HARDWARE_ENDSTOP_Y
         return (lastState & ENDSTOP_Y_MIN_ID) != 0;
+#else
+        return false;
+#endif
+    }
+    static INLINE bool y2Min() {
+#if (Y2_MIN_PIN > -1) && MIN_HARDWARE_ENDSTOP_Y2
+        return (lastState & ENDSTOP_Y2_MIN_ID) != 0;
 #else
         return false;
 #endif

--- a/src/ArduinoAVR/Repetier/Repetier.h
+++ b/src/ArduinoAVR/Repetier/Repetier.h
@@ -166,6 +166,12 @@ usage or for seraching for memory induced errors. Switch it off for production, 
 #define Y_STEP_DIRPOS 34
 #define X_STEP_DIRPOS 17
 #define Z_STEP_DIRPOS 68
+// Flags for dual motor gantry setups. Setting Y_STEP_KILL1 disables movement
+// of the first Y motor for the rest of the move, presumably because we hit
+// its endstop but haven't hit the endstop for the second motor yet.
+// Y_STEP_KILL2 is the converse.
+#define Y_STEP_KILL1 256
+#define Y_STEP_KILL2 512
 
 // add pid control
 #define TEMP_PID 1


### PR DESCRIPTION
(This is still a work in progress - hasn't yet been tested, and there are a few things that really ought to be cleaned up. Posting this now so that I can get some feedback on the direction I'm going, and particularly switching endstop statuses and direction flags to `flag16_t` as opposed to, say, having separate fields for the statuses of the different endstops and which motors have been killed. I'd also like to generalize this to X and Z as well - Z would be particularly useful with the plethora of printers with two separate steppers to raise the gantry.)

When using FEATURE_TWO_YSTEPPER, a second endstop can be set up
by setting MIN_HARDWARE_ENDSTOP_Y2 and Y2_MIN_PIN. When these are
set, hitting the first Y endstop causes only the first stepper to
stop. The second endstop must be hit in order for the second
stepper to stop as well. This allows both sides of a Y gantry to
be synced up automatically.
