### PR TITLE
Arduino Due native usb

### DIFF
--- a/src/ArduinoDUE/Repetier/HAL.cpp
+++ b/src/ArduinoDUE/Repetier/HAL.cpp
@@ -1102,7 +1102,8 @@ void PWM_TIMER_VECTOR ()
   if (pwm_pos_set[NUM_EXTRUDER] == pwm_count_heater && pwm_pos_set[NUM_EXTRUDER] != HEATER_PWM_MASK) WRITE(HEATED_BED_HEATER_PIN, HEATER_PINS_INVERTED);
 #endif
 #endif
-  HAL::allowInterrupts();
+  //HAL::allowInterrupts();
+  noInt.unprotect();
   counterPeriodical++; // Appxoimate a 100ms timer
   if (counterPeriodical >= 390) //  (int)(F_CPU/40960))
   {


### PR DESCRIPTION
This is a fix to get the native USB port of an Arduino Due to run properbly.
Short story:
PWM interrupt routine conflicted with the native USB port, causing the printer to stop working.

Long story:
After I got my RADDS board I switched to the Repetier Firmware, of course I wanted to use the native USB port for communication to not have my prints stutter or anything because of slow Serial communication.

So I generated my Firmware with SerialUSB support. 
I tried to print something and had to notice that the Print stopped after a few seconds.

After a few monthes now I had time to investigate the problem. I firstly wanted to know what is causing it and to not waste material I switched to dry run mode.
But in dry run mode the problem didn't appear.
So I had the guess It must have something to do with the extruder or the temperature handling.

So I investigated it further and noticed that there was a InterruptBlock class introduced.
And the HAL interrupt functions got disabled.

I found that the PWM interrupt was using the InterruptBlock class to prevent interrupts.
And I found that at the bottom Interrupt's should have been allowed again (HAL::allowInterrupts()).
But of course it couldn't enable the interrupts because the function got disabled.
So I changed the HAL function to the unprotect function of the InterruptBlock class and reflashed the firmware to the Arduino.

After a bit of testing I didn't got any stops anymore.
So I guess this fixed the problem for me and maybe for others too.

Greetings
Salandora