### PR TITLE
pins.h & ui.h: Improve support for UltiMaker - SD Detect and LCD

### DIFF
--- a/src/ArduinoAVR/Repetier/pins.h
+++ b/src/ArduinoAVR/Repetier/pins.h
@@ -555,10 +555,11 @@ STEPPER_CURRENT_CONTROL
 #define MOSI_PIN         51
 #define SDPOWER          -1
 #define SDSS             53
+#define SDCARDETECT	 38
 
+#define E0_PINS ORIG_E0_STEP_PIN,ORIG_E0_DIR_PIN,ORIG_E0_ENABLE_PIN,
 #define E1_PINS ORIG_E1_STEP_PIN,ORIG_E1_DIR_PIN,ORIG_E1_ENABLE_PIN,
-#define E2_PINS ORIG_E2_STEP_PIN,ORIG_E2_DIR_PIN,ORIG_E2_ENABLE_PIN,
-#define E3_PINS E3_STEP_PIN,E3_DIR_PIN,E3_ENABLE_PIN,
+#define E2_PINS
 
 #endif
 
@@ -2194,14 +2195,6 @@ S3(ext)=9
 
 #ifndef FAN_BOARD_PIN
 #define FAN_BOARD_PIN -1
-#endif
-
-#if NUM_EXTRUDER==1
-#define E1_PINS
-#endif
-
-#if NUM_EXTRUDER<3
-#define E2_PINS
 #endif
 
 #ifndef HEATER_PINS_INVERTED

--- a/src/ArduinoAVR/Repetier/ui.h
+++ b/src/ArduinoAVR/Repetier/ui.h
@@ -486,6 +486,23 @@ void ui_check_slow_keys(int &action) {}
 #define UI_ENCODER_B           11
 #define UI_ENCODER_CLICK       43
 #define UI_RESET_PIN           46
+#elif MOTHERBOARD == 37 // UltiMaker 1.5.7
+#define BEEPER_PIN 18
+#define UI_DISPLAY_RS_PIN      20
+#define UI_DISPLAY_RW_PIN      -1
+#define UI_DISPLAY_ENABLE_PIN  17
+#define UI_DISPLAY_D0_PIN      -1
+#define UI_DISPLAY_D1_PIN      -1
+#define UI_DISPLAY_D2_PIN      -1
+#define UI_DISPLAY_D3_PIN      -1
+#define UI_DISPLAY_D4_PIN      16
+#define UI_DISPLAY_D5_PIN      21
+#define UI_DISPLAY_D6_PIN      5
+#define UI_DISPLAY_D7_PIN      6
+#define UI_ENCODER_A           42
+#define UI_ENCODER_B           40
+#define UI_ENCODER_CLICK       19
+#define UI_RESET_PIN           -1
 #else
 #define BEEPER_PIN             37
 #define UI_DISPLAY_RS_PIN      16
@@ -511,12 +528,16 @@ void ui_check_slow_keys(int &action) {}
 void ui_init_keys() {
   UI_KEYS_INIT_CLICKENCODER_LOW(UI_ENCODER_A,UI_ENCODER_B); // click encoder on pins 47 and 45. Phase is connected with gnd for signals.
   UI_KEYS_INIT_BUTTON_LOW(UI_ENCODER_CLICK); // push button, connects gnd to pin
+#if UI_RESET_PIN > -1
   UI_KEYS_INIT_BUTTON_LOW(UI_RESET_PIN); // Kill pin
+#endif
 }
 void ui_check_keys(int &action) {
  UI_KEYS_CLICKENCODER_LOW_REV(UI_ENCODER_A,UI_ENCODER_B); // click encoder on pins 47 and 45. Phase is connected with gnd for signals.
  UI_KEYS_BUTTON_LOW(UI_ENCODER_CLICK,UI_ACTION_OK); // push button, connects gnd to pin
+#if UI_RESET_PIN > -1
  UI_KEYS_BUTTON_LOW(UI_RESET_PIN,UI_ACTION_RESET);
+#endif
 }
 inline void ui_check_slow_encoder() {}
 void ui_check_slow_keys(int &action) {}


### PR DESCRIPTION
This patch improves support for UltiMaker 1.5.7 (and derived boards, such as the Geeetech GT2560)

* Extruder pinout is now correct
* LCD pinout is now correct
* SD pinout is now correct