### PR TITLE
Implemented mirroring of Z axis to three stepper drivers

### DIFF
--- a/src/ArduinoAVR/Repetier/Configuration.h
+++ b/src/ArduinoAVR/Repetier/Configuration.h
@@ -1213,8 +1213,8 @@ IMPORTANT: With mode <>0 some changes in Configuration.h are not set any more, a
 
 /**************** duplicate motor driver ***************
 
-If you have an unused extruder stepper free, you could use it to drive the second z motor
-instead of driving both with a single stepper. The same works for the other axis if needed.
+If you have unused extruder steppers free, you could use it to drive the second or third z motor
+instead of driving them with a single stepper. The same works for the other axis if needed.
 */
 
 #define FEATURE_TWO_XSTEPPER 0
@@ -1231,6 +1231,11 @@ instead of driving both with a single stepper. The same works for the other axis
 #define Z2_STEP_PIN   E1_STEP_PIN
 #define Z2_DIR_PIN    E1_DIR_PIN
 #define Z2_ENABLE_PIN E1_ENABLE_PIN
+
+#define FEATURE_THREE_ZSTEPPER 0
+#define Z3_STEP_PIN   E2_STEP_PIN
+#define Z3_DIR_PIN    E2_DIR_PIN
+#define Z3_ENABLE_PIN E2_ENABLE_PIN
 
 /* Ditto printing allows 2 extruders to do the same action. This effectively allows
 to print an object two times at the speed of one. Works only with dual extruder setup.

--- a/src/ArduinoAVR/Repetier/Printer.cpp
+++ b/src/ArduinoAVR/Repetier/Printer.cpp
@@ -805,6 +805,15 @@ void Printer::setup()
 #endif
 #endif
 
+#if FEATURE_THREE_ZSTEPPER
+    SET_OUTPUT(Z3_STEP_PIN);
+    SET_OUTPUT(Z3_DIR_PIN);
+#if Z3_ENABLE_PIN > -1
+    SET_OUTPUT(Z3_ENABLE_PIN);
+    WRITE(Z3_ENABLE_PIN, !Z_ENABLE_ON);
+#endif
+#endif
+
     //endstop pullups
 #if MIN_HARDWARE_ENDSTOP_X
 #if X_MIN_PIN > -1

--- a/src/ArduinoAVR/Repetier/Printer.h
+++ b/src/ArduinoAVR/Repetier/Printer.h
@@ -472,6 +472,9 @@ public:
 #if FEATURE_TWO_ZSTEPPER && (Z2_ENABLE_PIN > -1)
         WRITE(Z2_ENABLE_PIN, !Z_ENABLE_ON);
 #endif
+#if FEATURE_THREE_ZSTEPPER && (Z3_ENABLE_PIN > -1)
+        WRITE(Z3_ENABLE_PIN, !Z_ENABLE_ON);
+#endif
     }
 
     /** \brief Enable stepper motor for x direction. */
@@ -503,6 +506,9 @@ public:
 #endif
 #if FEATURE_TWO_ZSTEPPER && (Z2_ENABLE_PIN > -1)
         WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON);
+#endif
+#if FEATURE_THREE_ZSTEPPER && (Z3_ENABLE_PIN > -1)
+        WRITE(Z3_ENABLE_PIN, Z_ENABLE_ON);
 #endif
     }
 
@@ -549,12 +555,18 @@ public:
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_DIR_PIN, !INVERT_Z_DIR);
 #endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_DIR_PIN, !INVERT_Z_DIR);
+#endif
         }
         else
         {
             WRITE(Z_DIR_PIN, INVERT_Z_DIR);
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_DIR_PIN, INVERT_Z_DIR);
+#endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_DIR_PIN, INVERT_Z_DIR);
 #endif
         }
     }
@@ -855,6 +867,9 @@ public:
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_STEP_PIN,START_STEP_WITH_HIGH);
 #endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_STEP_PIN,START_STEP_WITH_HIGH);
+#endif
             motorYorZ += 2;
         }
         else if(motorYorZ >= 2)
@@ -863,6 +878,9 @@ public:
             WRITE(Z_STEP_PIN,START_STEP_WITH_HIGH);
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_STEP_PIN,START_STEP_WITH_HIGH);
+#endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_STEP_PIN,START_STEP_WITH_HIGH);
 #endif
             motorYorZ -= 2;
         }
@@ -888,6 +906,9 @@ public:
 #if FEATURE_TWO_ZSTEPPER
         WRITE(Z2_STEP_PIN,START_STEP_WITH_HIGH);
 #endif
+#if FEATURE_THREE_ZSTEPPER
+        WRITE(Z3_STEP_PIN,START_STEP_WITH_HIGH);
+#endif
     }
     static INLINE void endXYZSteps()
     {
@@ -902,6 +923,9 @@ public:
         WRITE(Z_STEP_PIN,!START_STEP_WITH_HIGH);
 #if FEATURE_TWO_ZSTEPPER
         WRITE(Z2_STEP_PIN,!START_STEP_WITH_HIGH);
+#endif
+#if FEATURE_THREE_ZSTEPPER
+        WRITE(Z3_STEP_PIN,!START_STEP_WITH_HIGH);
 #endif
     }
     static INLINE speed_t updateStepsPerTimerCall(speed_t vbase)

--- a/src/ArduinoDUE/Repetier/Configuration.h
+++ b/src/ArduinoDUE/Repetier/Configuration.h
@@ -1202,6 +1202,11 @@ instead of driving both with a single stepper. The same works for the other axis
 #define Z2_DIR_PIN    E1_DIR_PIN
 #define Z2_ENABLE_PIN E1_ENABLE_PIN
 
+#define FEATURE_THREE_ZSTEPPER 0
+#define Z3_STEP_PIN   E2_STEP_PIN
+#define Z3_DIR_PIN    E2_DIR_PIN
+#define Z3_ENABLE_PIN E2_ENABLE_PIN
+
 /* Ditto printing allows 2 extruders to do the same action. This effectively allows
 to print an object two times at the speed of one. Works only with dual extruder setup.
 */

--- a/src/ArduinoDUE/Repetier/Printer.cpp
+++ b/src/ArduinoDUE/Repetier/Printer.cpp
@@ -805,6 +805,15 @@ void Printer::setup()
 #endif
 #endif
 
+#if FEATURE_THREE_ZSTEPPER
+    SET_OUTPUT(Z3_STEP_PIN);
+    SET_OUTPUT(Z3_DIR_PIN);
+#if Z3_ENABLE_PIN > -1
+    SET_OUTPUT(Z3_ENABLE_PIN);
+    WRITE(Z3_ENABLE_PIN, !Z_ENABLE_ON);
+#endif
+#endif
+
     //endstop pullups
 #if MIN_HARDWARE_ENDSTOP_X
 #if X_MIN_PIN > -1

--- a/src/ArduinoDUE/Repetier/Printer.h
+++ b/src/ArduinoDUE/Repetier/Printer.h
@@ -472,6 +472,9 @@ public:
 #if FEATURE_TWO_ZSTEPPER && (Z2_ENABLE_PIN > -1)
         WRITE(Z2_ENABLE_PIN, !Z_ENABLE_ON);
 #endif
+#if FEATURE_THREE_ZSTEPPER && (Z3_ENABLE_PIN > -1)
+        WRITE(Z3_ENABLE_PIN, !Z_ENABLE_ON);
+#endif
     }
 
     /** \brief Enable stepper motor for x direction. */
@@ -503,6 +506,9 @@ public:
 #endif
 #if FEATURE_TWO_ZSTEPPER && (Z2_ENABLE_PIN > -1)
         WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON);
+#endif
+#if FEATURE_THREE_ZSTEPPER && (Z3_ENABLE_PIN > -1)
+        WRITE(Z3_ENABLE_PIN, Z_ENABLE_ON);
 #endif
     }
 
@@ -549,12 +555,18 @@ public:
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_DIR_PIN, !INVERT_Z_DIR);
 #endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_DIR_PIN, !INVERT_Z_DIR);
+#endif
         }
         else
         {
             WRITE(Z_DIR_PIN, INVERT_Z_DIR);
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_DIR_PIN, INVERT_Z_DIR);
+#endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_DIR_PIN, INVERT_Z_DIR);
 #endif
         }
     }
@@ -855,6 +867,9 @@ public:
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_STEP_PIN,START_STEP_WITH_HIGH);
 #endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_STEP_PIN,START_STEP_WITH_HIGH);
+#endif
             motorYorZ += 2;
         }
         else if(motorYorZ >= 2)
@@ -863,6 +878,9 @@ public:
             WRITE(Z_STEP_PIN,START_STEP_WITH_HIGH);
 #if FEATURE_TWO_ZSTEPPER
             WRITE(Z2_STEP_PIN,START_STEP_WITH_HIGH);
+#endif
+#if FEATURE_THREE_ZSTEPPER
+            WRITE(Z3_STEP_PIN,START_STEP_WITH_HIGH);
 #endif
             motorYorZ -= 2;
         }
@@ -888,6 +906,9 @@ public:
 #if FEATURE_TWO_ZSTEPPER
         WRITE(Z2_STEP_PIN,START_STEP_WITH_HIGH);
 #endif
+#if FEATURE_THREE_ZSTEPPER
+        WRITE(Z3_STEP_PIN,START_STEP_WITH_HIGH);
+#endif
     }
     static INLINE void endXYZSteps()
     {
@@ -902,6 +923,9 @@ public:
         WRITE(Z_STEP_PIN,!START_STEP_WITH_HIGH);
 #if FEATURE_TWO_ZSTEPPER
         WRITE(Z2_STEP_PIN,!START_STEP_WITH_HIGH);
+#endif
+#if FEATURE_THREE_ZSTEPPER
+        WRITE(Z3_STEP_PIN,!START_STEP_WITH_HIGH);
 #endif
     }
     static INLINE speed_t updateStepsPerTimerCall(speed_t vbase)


### PR DESCRIPTION
When using a printer like the sparkcube it sometimes is better to connect three z axis steppers to three stepper drivers instead of two (two motors in parallel to z axis stepper driver, one motor to e1 stepper driver).

I've implemented this feature. You can enable it in configuration.h using the FEATURE_THREE_ZSTEPPER define.