### PR TITLE
JSON-formatted responses (M408, M20 S2, M36)

### DIFF
--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -1555,7 +1555,7 @@ void Commands::processMCode(GCode *com)
         }
         break;
 #endif
-#if JSON_OUTPUT
+#if JSON_OUTPUT && SDSUPPORT
     case 36: // M36 JSON File Info
         if (com->hasString()) {
             sd.JSONFileInfo(com->text);


### PR DESCRIPTION
This patch adds JSON-formatted responses to M20 S2, M408 and M36.
This makes Repetier-Firmware work with ESP8266 Duet web interface, PanelDue and probably some other things.
Tested with RADDS and RAPMS 1.4.