### PR TITLE
Expanded distortion correction for cartesian printers

### DIFF
--- a/src/ArduinoAVR/Repetier/Printer.cpp
+++ b/src/ArduinoAVR/Repetier/Printer.cpp
@@ -2203,7 +2203,7 @@ int32_t Distortion::correct(int32_t x, int32_t y, int32_t z) const
 
 int32_t Distortion::correctExtrusion(int32_t x, int32_t y, int32_t z, int32_t e) const
 {
-    //TODO Retracts are multiblied at the moment. This causes strings in layers. (zStart < layers < zEnd)
+    //TODO Retracts are multiplied at the moment. This causes strings in layers. (zStart < layers < zEnd)
     if (!enabled || z > zEnd || z < zStart || Printer::isZProbingActive()){
       return e;
     }

--- a/src/ArduinoAVR/Repetier/Printer.cpp
+++ b/src/ArduinoAVR/Repetier/Printer.cpp
@@ -2181,7 +2181,8 @@ int32_t Distortion::correct(int32_t x, int32_t y, int32_t z) const
       Com::printF(PSTR(" iy= "), fyFloor); Com::printFLN(PSTR(" fy= "), fy);
     }
     if (z > zStart && z > 0)
-        correction_z = (correction_z * (zEnd - z)) / (zEnd - zStart);
+        //All variables are type int. For calculation we need float values
+        correction_z = (correction_z * static_cast<float>(zEnd - z) / (zEnd - zStart));
    /* if(correction_z > 20 || correction_z < -20) {
             Com::printFLN(PSTR("Corr. error too big:"),correction_z);
         Com::printF(PSTR("fxf"),(int)fxFloor);
@@ -2198,6 +2199,19 @@ int32_t Distortion::correct(int32_t x, int32_t y, int32_t z) const
         correction_z = 0;
     }*/
     return correction_z;
+}
+
+int32_t Distortion::correctExtrusion(int32_t x, int32_t y, int32_t z, int32_t e) const
+{
+    //TODO Retracts are multiblied at the moment. This causes strings in layers. (zStart < layers < zEnd)
+    if (!enabled || z > zEnd || z < zStart || Printer::isZProbingActive()){
+      return e;
+    }
+    //calculate Extrusionmultiplier for zStart < z < zEnd
+    int32_t zCor = correct(x, y, 0); 
+    //float correction_e = static_cast<float>((zEnd - zStart) - zCor) / (zEnd - zStart);
+    float correction_e = static_cast<float>((zEnd - zStart) - zCor) / (zEnd - zStart);
+    return round(correction_e * e);
 }
 
 void Distortion::set(float x,float y,float z) {

--- a/src/ArduinoAVR/Repetier/Printer.h
+++ b/src/ArduinoAVR/Repetier/Printer.h
@@ -125,7 +125,8 @@ public:
     void disable(bool permanent = true);
     bool measure(void);
     int32_t correct(int32_t x, int32_t y, int32_t z) const;
-    void updateDerived();
+    int32_t correctExtrusion(int32_t x, int32_t y, int32_t z, int32_t e) const;
+	void updateDerived();
     void reportStatus();
 	bool isEnabled() {return enabled;}
 	int32_t zMaxSteps() {return zEnd;}	


### PR DESCRIPTION
Hi Roland,

Distortion correction is a real cool feature, but it didn’t work on our Cartesian printer. So I made a few changes. Now it works at our printer. (X350)
Splitting segments behaved a little bit strange. It moved up for the first segment and down all the others.
For distorted layers there is now an Extrusion correction. The bed for testing had a distortion of ~0.35mm and the prints are pretty nice.

Best regards,
Andreas
