### PR TITLE
Zonestar config fixes

### DIFF
--- a/boards/Zonestar P802M/Configuration.h
+++ b/boards/Zonestar P802M/Configuration.h
@@ -397,7 +397,7 @@ WARNING: Servos can draw a considerable amount of current. Make sure your system
 #define UI_SERVO_CONTROL 0
 #define FAN_KICKSTART_TIME  200
 
-        #define FEATURE_WATCHDOG 1
+        #define FEATURE_WATCHDOG 0
 
 // #################### Z-Probing #####################
 
@@ -740,7 +740,7 @@ Values must be in range 1..255
     "servo1Pin": -1,
     "servo2Pin": -1,
     "servo3Pin": -1,
-    "featureWatchdog": "1",
+    "featureWatchdog": "0",
     "hasHeatedBed": "1",
     "enableZProbing": "0",
     "extrudeMaxLength": 160,

--- a/boards/Zonestar P802M/Configuration.h
+++ b/boards/Zonestar P802M/Configuration.h
@@ -551,7 +551,7 @@ Values must be in range 1..255
     "bluetoothBaudrate": 115200,
     "xStepsPerMM": 100,
     "yStepsPerMM": 100,
-    "zStepsPerMM": 400,
+    "zStepsPerMM": 1600,
     "xInvert": 0,
     "xInvertEnable": 0,
     "eepromMode": 1,

--- a/boards/Zonestar P802M/README.txt
+++ b/boards/Zonestar P802M/README.txt
@@ -32,6 +32,10 @@ IMPORTANT NOTES:
   Z mechanics. Some of them require 400 Z-steps/mm, some 1600. The latter
   value is used by default, but if you have issues with Z-steps - change
   them to 400.
+- At least some Zonestar printers have issues with Watchdog enabled.
+  Particularly, if no SD card inserted, such printers with watchdog enabled
+  cannot boot and constantly restart. So by default the watchdog option is
+  now disabled. Enable it if desired.
 
 Do not forget about EEPROM modes, so you use this firmware settings and not
 previously stored. M502 (restore firmware defaults), M500 (save to EEPROM)

--- a/boards/Zonestar P802M/README.txt
+++ b/boards/Zonestar P802M/README.txt
@@ -27,6 +27,12 @@ TO BUILD THE FIRMWARE:
   if desired. Download new Configuration.h if changed, or firmware zip bundle.
 - Build and flash the firmware.
 
+IMPORTANT NOTES:
+- It seems that some Zonestar printers have different steppers and/or
+  Z mechanics. Some of them require 400 Z-steps/mm, some 1600. The latter
+  value is used by default, but if you have issues with Z-steps - change
+  them to 400.
+
 Do not forget about EEPROM modes, so you use this firmware settings and not
 previously stored. M502 (restore firmware defaults), M500 (save to EEPROM)
 commands may help.


### PR DESCRIPTION
Someone has changed Z-steps/mm from 400 to 1600, and at least one printer (apart from mine) had issue today. So I kept the change but added a comment about possible differences in printer hardware. Also fixed JSON part of config (using Web UI that is safer and cleaner).

Another fix is to disable watchdog in the config by default. Without it printer never boots if no SD card inserted (init time >1s).