### PR TITLE
HAL: enable servo option for ATmega1284P (Sanguino, Melzi, etc)

### DIFF
--- a/src/ArduinoAVR/Repetier/HAL.cpp
+++ b/src/ArduinoAVR/Repetier/HAL.cpp
@@ -499,7 +499,7 @@ unsigned char HAL::i2cReadNak(void)
 }
 
 #if FEATURE_SERVO
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__) || defined(__AVR_ATmega128__) ||defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__) || defined(__AVR_ATmega128__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega2561__)
 #define SERVO2500US F_CPU/3200
 #define SERVO5000US F_CPU/1600
 unsigned int HAL::servoTimings[4] = {0,0,0,0};


### PR DESCRIPTION
This patch enables servo support on ATmega1284P boards.
Tested on Melzi (Zonestar P802M printer), used with mechanical Z-probe on a servo lever.
