### PR TITLE
Compiler warning - no return statement for non-void function

### DIFF
--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -262,7 +262,7 @@ void Commands::reportPrinterUsage() {
 // Digipot methods for controling current and microstepping
 
 #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
-int digitalPotWrite(int address, uint16_t value) { // From Arduino DigitalPotControl example
+void digitalPotWrite(int address, uint16_t value) { // From Arduino DigitalPotControl example
     if(value > 255)
         value = 255;
     WRITE(DIGIPOTSS_PIN,LOW); // take the SS pin low to select the chip

--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -269,7 +269,6 @@ void digitalPotWrite(int address, uint16_t value) { // From Arduino DigitalPotCo
     HAL::spiSend(address); //  send in the address and value via SPI:
     HAL::spiSend(value);
     WRITE(DIGIPOTSS_PIN,HIGH); // take the SS pin high to de-select the chip:
-    //delay(10);
 }
 
 void setMotorCurrent(uint8_t driver, uint16_t current) {


### PR DESCRIPTION
Compiler warning during build of master. Just changed return type, removed commented out code.

> /tmp/build7aa7be57480c79d9d1f62e5e1de5b63d.tmp/sketch/Commands.cpp: In function 'int digitalPotWrite(int, uint16_t)':
> /tmp/build7aa7be57480c79d9d1f62e5e1de5b63d.tmp/sketch/Commands.cpp:273:1: warning: no return statement in function returning non-void [-Wreturn-type]
