### PR TITLE
add PWM support for controlling Laser (Intensity) and CNC (rpm) 

### DIFF
--- a/src/ArduinoAVR/Repetier/Configuration.h
+++ b/src/ArduinoAVR/Repetier/Configuration.h
@@ -776,9 +776,9 @@ LASER_PWM use a PWM to control the output power (M3 Sxxx 0-255)
 Note: PWM can not be used with Servos
 */
 
-#define SUPPORT_LASER 1 // set 1 to enable laser support
+#define SUPPORT_LASER 0 // set 1 to enable laser support
 //#define LASER_TYPE LASER_TYPE_PWM
-#define LASER_TYPE LASER_ON_OFF
+#define LASER_TYPE LASER_TYPE_ONOFF
 #define LASER_PIN -1    // set to pin enabling laser
 #define LASER_ON_HIGH 1 // Set 0 if low signal enables laser
 
@@ -801,7 +801,9 @@ It also can add a delay to wait for spindle to run on full speed.
 #define CNC_ENABLE_WITH 1 // Set 0 if low enables spindle
 #define CNC_DIRECTION_PIN -1 // Set to pin if direction control is possible
 #define CNC_DIRECTION_CW 1 // Set signal required for clockwise rotation
-
+#define CNC_PWM_PIN -1  // PWM pin for controlling Speed (RPM)
+#define CNC_PWM_INV 0 //Invert the PWM
+#define CNC_MAX_RPM 12000 // MAX RPM of the Tool
 
 /* Select the default mode when the printer gets enables. Possible values are
 PRINTER_MODE_FFF 0

--- a/src/ArduinoAVR/Repetier/Configuration.h
+++ b/src/ArduinoAVR/Repetier/Configuration.h
@@ -769,11 +769,19 @@ and G0 moves have it disables.
 
 In any case, laser only enables while moving. At the end of a move it gets
 automatically disabled. 
+
+Laser Types
+LASER_ON_OFF only enable an disable the Laser
+LASER_PWM use a PWM to control the output power (M3 Sxxx 0-255)
+Note: PWM can not be used with Servos
 */
 
-#define SUPPORT_LASER 0 // set 1 to enable laser support
+#define SUPPORT_LASER 1 // set 1 to enable laser support
+//#define LASER_TYPE LASER_TYPE_PWM
+#define LASER_TYPE LASER_ON_OFF
 #define LASER_PIN -1    // set to pin enabling laser
 #define LASER_ON_HIGH 1 // Set 0 if low signal enables laser
+
 
 // ##########################################################################################
 // ##                              CNC configuration                                       ##

--- a/src/ArduinoAVR/Repetier/Drivers.cpp
+++ b/src/ArduinoAVR/Repetier/Drivers.cpp
@@ -157,6 +157,10 @@ void CNCDriver::initialize()
 #if CNC_DIRECTION_PIN > -1
         SET_OUTPUT(CNC_DIRECTION_PIN);
 #endif
+#if CNC_PWM_PIN > -1
+        SET_OUTPUT(CNC_PWM_PIN);
+        WRITE(CNC_PWM_PIN, CNC_PWM_INV);
+#endif
     }
 }
 /** Turns off spindle. For event override implement
@@ -168,6 +172,9 @@ void CNCDriver::spindleOff()
     if(direction == 0) return; // already off
     if(EVENT_SPINDLE_OFF)
     {
+#if CNC_PWM_PIN > -1
+        HAL::setPWM(0, CNC_PWM_PIN, CNC_PWM_INV);
+#endif
 #if CNC_ENABLE_PIN > -1
         WRITE(CNC_ENABLE_PIN,!CNC_ENABLE_WITH);
 #endif
@@ -187,6 +194,16 @@ void CNCDriver::spindleOnCW(int32_t rpm)
     spindleOff();
     direction = 1;
     if(EVENT_SPINDLE_CW(rpm)) {
+#if CNC_PWM_PIN > -1
+#if defined(CNC_MAX_RPM)
+        if(rpm > CNC_MAX_RPM) {
+            rpm = CNC_MAX_RPM;
+        }
+        HAL::setPWM((uint8_t)(rpm/(CNC_MAX_RPM/TOOL_PWM_STEPS)), CNC_PWM_PIN, CNC_PWM_INV);
+#else
+        HAL::setPWM(rpm, CNC_PWM_PIN, CNC_PWM_INV);
+#endif
+#endif
 #if CNC_DIRECTION_PIN > -1
         WRITE(CNC_DIRECTION_PIN, CNC_DIRECTION_CW);
 #endif
@@ -208,6 +225,16 @@ void CNCDriver::spindleOnCCW(int32_t rpm)
     spindleOff();
     direction = -1;
     if(EVENT_SPINDLE_CW(rpm)) {
+#if CNC_PWM_PIN > -1
+#if defined(CNC_MAX_RPM)
+        if(rpm > CNC_MAX_RPM) {
+            rpm = CNC_MAX_RPM;
+        }
+        HAL::setPWM((uint8_t)(rpm/(CNC_MAX_RPM/TOOL_PWM_STEPS)), CNC_PWM_PIN, CNC_PWM_INV);
+#else
+        HAL::setPWM(rpm, CNC_PWM_PIN, CNC_PWM_INV);
+#endif
+#endif
 #if CNC_DIRECTION_PIN > -1
         WRITE(CNC_DIRECTION_PIN, !CNC_DIRECTION_CW);
 #endif

--- a/src/ArduinoAVR/Repetier/Drivers.cpp
+++ b/src/ArduinoAVR/Repetier/Drivers.cpp
@@ -116,6 +116,7 @@ void LaserDriver::initialize()
     {
 #if LASER_PIN > -1
         SET_OUTPUT(LASER_PIN);
+        WRITE(LASER_PIN, !LASER_ON_HIGH); // be sure laser is off!
 #endif
     }
     changeIntensity(0);
@@ -126,7 +127,11 @@ void LaserDriver::changeIntensity(uint8_t newIntensity)
     {
         // Default implementation
 #if LASER_PIN > -1
+#if (LASER_TYPE == LASER_ON_OFF)
         WRITE(LASER_PIN,(LASER_ON_HIGH ? newIntensity > 199 : newIntensity < 200));
+#elif (LASER_TYPE == LASER_PWM)
+        HAL::setPWM(LASER_PIN, newIntensity, !LASER_ON_HIGH);
+#endif
 #endif
     }
 }

--- a/src/ArduinoAVR/Repetier/HAL.h
+++ b/src/ArduinoAVR/Repetier/HAL.h
@@ -187,6 +187,15 @@ typedef uint8_t ufast8_t;
 #define SERIAL_TX_BUFFER_MASK 63
 #endif
 
+#if (FEATURE_TOOL_PWM)
+    typedef struct {
+        int8_t pin;
+        uint8_t pwm;
+        bool state;
+        bool inv;
+    } t_tool_pwm_cfg;
+#endif
+
 struct ring_buffer
 {
     uint8_t buffer[SERIAL_BUFFER_SIZE];
@@ -709,15 +718,9 @@ public:
 
     // Software PWM
 #if (FEATURE_TOOL_PWM)
-    typedef struct {
-            int8_t pin;
-            uint8_t pwm;
-            bool state;
-            bool inv;
-    } t_tool_pwm_cfg;
-
     static t_tool_pwm_cfg tool_cfg;
     static void setPWM(uint8_t val, int8_t pin, bool inv);
+    static void timer3_irq(void);
 #endif
 
     // Watchdog support

--- a/src/ArduinoAVR/Repetier/HAL.h
+++ b/src/ArduinoAVR/Repetier/HAL.h
@@ -706,6 +706,20 @@ public:
     static uint8_t i2cReadAck(void);
     static uint8_t i2cReadNak(void);
 
+
+    // Software PWM
+#if (FEATURE_TOOL_PWM)
+    typedef struct {
+            int8_t pin;
+            uint8_t pwm;
+            bool state;
+            bool inv;
+    } t_tool_pwm_cfg;
+
+    static t_tool_pwm_cfg tool_cfg;
+    static void setPWM(uint8_t val, int8_t pin, bool inv);
+#endif
+
     // Watchdog support
 
     inline static void startWatchdog()

--- a/src/ArduinoAVR/Repetier/Repetier.h
+++ b/src/ArduinoAVR/Repetier/Repetier.h
@@ -185,6 +185,19 @@ usage or for searching for memory induced errors. Switch it off for production, 
 // add pid control
 #define TEMP_PID 1
 
+#define PRINTER_MODE_FFF 0
+#define PRINTER_MODE_LASER 1
+#define PRINTER_MODE_CNC 2
+
+#define ILLEGAL_Z_PROBE -888
+
+// we can not prevent this as some configurations need a parameter and others not
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
+#include "Configuration.h"
+
+
 // HAL Tool PWM
 #define FEATURE_TOOL_PWM 0
 #ifndef TOOL_PWM_HZ
@@ -200,10 +213,10 @@ usage or for searching for memory induced errors. Switch it off for production, 
 #define LASER_TYPE_PWM 2
 
 #if defined(SUPPORT_LASER) && SUPPORT_LASER
-#if ((LASER_TYPE == LASER_TYPE_PWM) && (LASER_PIN > -1))
-#if defined(FEATURE_SERVO) && FEATURE_SERVO
-#error Servos and Laser PWM not possible on the same time
+#ifndef LASER_TYPE
+#define LASER_TYPE LASER_TYPE_ONOFF
 #endif
+#if ((LASER_TYPE == LASER_TYPE_PWM) && (LASER_PIN > -1))
 // enable TOOL PWM
 #undef FEATURE_TOOL_PWM
 #define FEATURE_TOOL_PWM 1
@@ -211,18 +224,18 @@ usage or for searching for memory induced errors. Switch it off for production, 
 #endif
 
 
+#if defined(SUPPORT_CNC) && SUPPORT_CNC
+#if defined(CNC_PWM_PIN) && (CNC_PWM_PIN > -1)
+// enable TOOL PWM
+#undef FEATURE_TOOL_PWM
+#define FEATURE_TOOL_PWM 1
+#endif
+#endif
 
-#define PRINTER_MODE_FFF 0
-#define PRINTER_MODE_LASER 1
-#define PRINTER_MODE_CNC 2
+#if (defined(FEATURE_SERVO) && FEATURE_SERVO) && (defined(FEATURE_TOOL_PWM) && FEATURE_TOOL_PWM)
+#error Servos and Tool PWM not possible on the same time
+#endif
 
-#define ILLEGAL_Z_PROBE -888
-
-// we can not prevent this as some configurations need a parameter and others not
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-
-#include "Configuration.h"
 
 #ifndef SHARED_EXTRUDER_HEATER
 #define SHARED_EXTRUDER_HEATER 0

--- a/src/ArduinoAVR/Repetier/Repetier.h
+++ b/src/ArduinoAVR/Repetier/Repetier.h
@@ -185,6 +185,33 @@ usage or for searching for memory induced errors. Switch it off for production, 
 // add pid control
 #define TEMP_PID 1
 
+// HAL Tool PWM
+#define FEATURE_TOOL_PWM 0
+#ifndef TOOL_PWM_HZ
+#define TOOL_PWM_HZ 100
+#endif
+#ifndef TOOL_PWM_STEPS
+#define TOOL_PWM_STEPS 255
+#endif
+
+// Laser Type
+#define LASER_TYPE_OFF 0
+#define LASER_TYPE_ONOFF 1
+#define LASER_TYPE_PWM 2
+
+#if defined(SUPPORT_LASER) && SUPPORT_LASER
+#if ((LASER_TYPE == LASER_TYPE_PWM) && (LASER_PIN > -1))
+#if defined(FEATURE_SERVO) && FEATURE_SERVO
+#error Servos and Laser PWM not possible on the same time
+#endif
+// enable TOOL PWM
+#undef FEATURE_TOOL_PWM
+#define FEATURE_TOOL_PWM 1
+#endif
+#endif
+
+
+
 #define PRINTER_MODE_FFF 0
 #define PRINTER_MODE_LASER 1
 #define PRINTER_MODE_CNC 2


### PR DESCRIPTION
this patch allow to control a Tools via PWM.
for example the Laser power or the CNC rpm.

all functions are inside defines to allow disabling the PWM feature complete 

Note:
since timer3 is used combining this with Servos is not possible.