### PR TITLE
Fix rotation point for transformation matrix for auto bed leveling

### DIFF
--- a/src/ArduinoAVR/Repetier/BedLeveling.cpp
+++ b/src/ArduinoAVR/Repetier/BedLeveling.cpp
@@ -331,7 +331,7 @@ bool runBedLeveling(GCode *com) {
         Com::printFLN(PSTR("Z after rotation:"),zRot);
         // With max z endstop we adjust zlength so after next homing we have also a calibrated printer
         if(s != 0) {
-            Printer::zLength += currentZ - zRot;
+            Printer::zLength += plane.z((float)Printer::currentPositionSteps[X_AXIS] * Printer::invAxisStepsPerMM[X_AXIS],(float)Printer::currentPositionSteps[Y_AXIS] * Printer::invAxisStepsPerMM[Y_AXIS]) - zRot;
             Com::printFLN(Com::tZProbePrinterHeight, Printer::zLength);
         }
 #endif

--- a/src/ArduinoAVR/Repetier/BedLeveling.cpp
+++ b/src/ArduinoAVR/Repetier/BedLeveling.cpp
@@ -320,7 +320,7 @@ bool runBedLeveling(GCode *com) {
 
         // Leveling is finished now update own position and store leveling data if needed.
         // Zero point here because rotation matrix rotates through zero point, not through current position point. 
-		float currentZ = plane.z((float)0,(float)0);
+        float currentZ = plane.z((float)0,(float)0);
         Com::printF(PSTR("CurrentZ:"),currentZ);
         Com::printFLN(PSTR(" atZ:"),Printer::currentPosition[Z_AXIS]);
         // With max z endstop we adjust zlength so after next homing we have also a calibrated printer

--- a/src/ArduinoAVR/Repetier/BedLeveling.cpp
+++ b/src/ArduinoAVR/Repetier/BedLeveling.cpp
@@ -318,8 +318,9 @@ bool runBedLeveling(GCode *com) {
         }
         correctAutolevel(com,plane);
 
-        // Leveling is finished now update own positions and store leveling data if needed
-        float currentZ = plane.z((float)Printer::currentPositionSteps[X_AXIS] * Printer::invAxisStepsPerMM[X_AXIS],(float)Printer::currentPositionSteps[Y_AXIS] * Printer::invAxisStepsPerMM[Y_AXIS]);
+        // Leveling is finished now update own position and store leveling data if needed.
+        // Zero point here because rotation matrix rotates through zero point, not through current position point. 
+		float currentZ = plane.z((float)0,(float)0);
         Com::printF(PSTR("CurrentZ:"),currentZ);
         Com::printFLN(PSTR(" atZ:"),Printer::currentPosition[Z_AXIS]);
         // With max z endstop we adjust zlength so after next homing we have also a calibrated printer


### PR DESCRIPTION
There is a bug in auto bed leveling logic. After measurement bed plane we have to adjust current z position from bed plane at zero point, not at current position point because transformation matrix performs rotation through zero point.

###### For example, old behavior of G32:
_10:17:37.527: Z-probe:20.00 X:20.00 Y:20.00
10:17:55.232: Z-probe:18.95 X:160.00 Y:20.00
10:18:12.466: Z-probe:19.05 X:100.00 Y:145.00    **; This is measured point. We can be sure that bed is 19.05mm far away at this position.**
10:18:17.583: plane: a = -0.0075 b = -0.0025 c = 20.1978
10:18:17.592: Transformation matrix: 0.999972 0.000000 0.007471 -0.000019 0.999997 0.002504 -0.007471 -0.002504 0.999969
10:18:17.595: CurrentZ:18.88 atZ:23.00
10:18:18.047: Info:Autoleveling enabled
10:18:18.049: X:100.14 Y:145.04 Z:17.764 E:0.0000  **; Wow, we measured this point few lines before, and we got 19.05 as z-level, so after all transformations here should be 19.05 at Z**_
###### New behavior:
_10:33:46.499: Z-probe:25.97 X:20.00 Y:20.00
10:34:10.184: Z-probe:24.93 X:160.00 Y:20.00
10:34:33.396: Z-probe:25.05 X:100.00 Y:145.00   **; Same place, measured Z here is true distance (regardless that is 5 mm greater than in previous example)**
10:34:41.512: plane: a = -0.0074 b = -0.0023 c = 26.1634
10:34:41.520: Transformation matrix: 0.999973 0.000000 0.007410 -0.000017 0.999997 0.002342 -0.007410 -0.002342 0.999970
10:34:41.522: CurrentZ:26.16 atZ:28.95 **; Actually it is CurrentZ before transformation matrix applied** 
10:34:41.978: Info:Autoleveling enabled
10:35:03.686: X:100.19 Y:145.06 Z:25.081 E:0.0000 **Now here after applying transformation we have same Z as measured before**_  