### PR TITLE
Fix parsing of extended gcode arguments and remove extra G0 laser-off from G2/G3

### DIFF
--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -908,19 +908,7 @@ void Commands::processGCode(GCode *com) {
 #if ARC_SUPPORT
         case 2: // CW Arc
         case 3: // CCW Arc MOTION_MODE_CW_ARC: case MOTION_MODE_CCW_ARC:
-#if defined(SUPPORT_LASER) && SUPPORT_LASER
-            {
-                // disable laser for G0 moves
-                bool laserOn = LaserDriver::laserOn;
-                if(com->G == 0 && Printer::mode == PRINTER_MODE_LASER) {
-                    LaserDriver::laserOn = false;
-                }
-#endif // defined
-                processArc(com);
-#if defined(SUPPORT_LASER) && SUPPORT_LASER
-                LaserDriver::laserOn = laserOn;
-            }
-#endif // defined
+            processArc(com);
             break;
 #endif
         case 4: // G4 dwell

--- a/src/ArduinoAVR/Repetier/gcode.cpp
+++ b/src/ArduinoAVR/Repetier/gcode.cpp
@@ -887,7 +887,7 @@ bool GCode::parseAscii(char *line,bool fromSerial)
         case 'C':
         case 'c':
         {
-	        D = parseFloatValue(pos);
+	        C = parseFloatValue(pos);
 	        params2 |= 16;
 	        params |= 4096; // Needs V2 for saving
 	        break;
@@ -895,7 +895,7 @@ bool GCode::parseAscii(char *line,bool fromSerial)
         case 'H':
         case 'h':
         {
-	        D = parseFloatValue(pos);
+	        H = parseFloatValue(pos);
 	        params2 |= 32;
 	        params |= 4096; // Needs V2 for saving
 	        break;
@@ -903,7 +903,7 @@ bool GCode::parseAscii(char *line,bool fromSerial)
         case 'A':
         case 'a':
         {
-	        D = parseFloatValue(pos);
+	        A = parseFloatValue(pos);
 	        params2 |= 64;
 	        params |= 4096; // Needs V2 for saving
 	        break;
@@ -911,7 +911,7 @@ bool GCode::parseAscii(char *line,bool fromSerial)
         case 'B':
         case 'b':
         {
-	        D = parseFloatValue(pos);
+	        B = parseFloatValue(pos);
 	        params2 |= 128;
 	        params |= 4096; // Needs V2 for saving
 	        break;
@@ -919,7 +919,7 @@ bool GCode::parseAscii(char *line,bool fromSerial)
         case 'K':
         case 'k':
         {
-	        D = parseFloatValue(pos);
+	        K = parseFloatValue(pos);
 	        params2 |= 256;
 	        params |= 4096; // Needs V2 for saving
 	        break;
@@ -927,7 +927,7 @@ bool GCode::parseAscii(char *line,bool fromSerial)
         case 'L':
         case 'l':
         {
-	        D = parseFloatValue(pos);
+	        L = parseFloatValue(pos);
 	        params2 |= 512;
 	        params |= 4096; // Needs V2 for saving
 	        break;
@@ -935,7 +935,7 @@ bool GCode::parseAscii(char *line,bool fromSerial)
         case 'O':
         case 'o':
         {
-	        D = parseFloatValue(pos);
+	        O = parseFloatValue(pos);
 	        params2 |= 1024;
 	        params |= 4096; // Needs V2 for saving
 	        break;


### PR DESCRIPTION
These changes fix the variables used for parsing the extended gcode arguments C, H, A, B, K, L, and O, instead of incorrectly parsing into 'D'.   And removes the useless laser-off guard for G0 commands in the G2/G3 processing case, as the 'if' is always false.

Note: this should be merged to the 'development' and 'work092' branches as well, as they both have the same issue.
