### PR TITLE
Allow M117 commands in SD prints

### DIFF
--- a/src/ArduinoAVR/Repetier/SDCard.cpp
+++ b/src/ArduinoAVR/Repetier/SDCard.cpp
@@ -129,6 +129,7 @@ void SDCard::startPrint()
     sdmode = 1;
     Printer::setMenuMode(MENU_MODE_SD_PRINTING, true);
     Printer::setMenuMode(MENU_MODE_SD_PAUSED, false);
+    UI_STATUS_RAM("");
 }
 void SDCard::pausePrint(bool intern)
 {

--- a/src/ArduinoAVR/Repetier/ui.cpp
+++ b/src/ArduinoAVR/Repetier/ui.cpp
@@ -1538,7 +1538,7 @@ void UIDisplay::parse(const char *txt,bool ram)
             if(c2 == 's')
             {
 #if SDSUPPORT
-                if(sd.sdactive && sd.sdmode)
+                if(sd.sdactive && sd.sdmode && !statusMsg[0])
                 {
                     addStringP(Com::translatedF(UI_TEXT_PRINT_POS_ID));
                     float percent;


### PR DESCRIPTION
This patch allows using M117 commands in gcode files printed directly from an SD card. I'm currently using this to display the remaining time as calculated by my gcodetimer tool (https://github.com/gonzalezjj/gcodetimer) and thought it could be something others might be interested in.