### PR TITLE
second display initialization should not execute MCP23017 init code when

### DIFF
--- a/src/ArduinoAVR/Repetier/ui.cpp
+++ b/src/ArduinoAVR/Repetier/ui.cpp
@@ -1051,7 +1051,7 @@ void UIDisplay::initialize()
 #if defined(USER_KEY4_PIN) && USER_KEY4_PIN > -1
     UI_KEYS_INIT_BUTTON_LOW(USER_KEY4_PIN);
 #endif
-#if UI_DISPLAY_TYPE == DISPLAY_I2C
+#if UI_DISPLAY_I2C_CHIPTYPE==1
     // I don't know why but after power up the lcd does not come up
     // but if I reinitialize i2c and the lcd again here it works.
     HAL::delayMilliseconds(10);


### PR DESCRIPTION
A configured PCF8574 gets MCP23017 init code while initializing display. PCF8574 has no control registers. It simply writes those bytes out to port. This can cause damages.
I could not test a real PCF8574-Display for now, but the current code is dangerous.