### PR TITLE
Fix issue with homing already homed delta printer

### DIFF
--- a/src/ArduinoAVR/Repetier/Printer.cpp
+++ b/src/ArduinoAVR/Repetier/Printer.cpp
@@ -1414,6 +1414,7 @@ void Printer::homeZAxis() // Delta z homing
 {
 	bool homingSuccess = false;
 	Endstops::resetAccumulator();
+	Endstops::fillFromAccumulator();
     deltaMoveToTopEndstops(Printer::homingFeedrate[Z_AXIS]);
 	// New safe homing routine by Kyrre Aalerud
 	// This method will safeguard against sticky endstops such as may be gotten cheaply from china.

--- a/src/ArduinoDUE/Repetier/Printer.cpp
+++ b/src/ArduinoDUE/Repetier/Printer.cpp
@@ -1414,6 +1414,7 @@ void Printer::homeZAxis() // Delta z homing
 {
 	bool homingSuccess = false;
 	Endstops::resetAccumulator();
+	Endstops::fillFromAccumulator();
     deltaMoveToTopEndstops(Printer::homingFeedrate[Z_AXIS]);
 	// New safe homing routine by Kyrre Aalerud
 	// This method will safeguard against sticky endstops such as may be gotten cheaply from china.


### PR DESCRIPTION
The function [homeZAxis](https://github.com/repetier/Repetier-Firmware/blob/be98278/src/ArduinoAVR/Repetier/Printer.cpp#L1413) for homing a delta printer didn't work correctly when the printer was already at home position. It didn't pass check for endstops [at line 1424](https://github.com/repetier/Repetier-Firmware/blob/be98278/src/ArduinoAVR/Repetier/Printer.cpp#L1424) as Endstops::accumulator was reset [at line 1416](https://github.com/repetier/Repetier-Firmware/blob/be98278/src/ArduinoAVR/Repetier/Printer.cpp#L1416) and no update to the accumulator was done.

Adding reseting actual state before move instruction fixed this issue on my machine.
Other option would be to force endstops update even if no change is detected when homing, but I'm just guessing.