### PR TITLE
fixed bug - doesn't compile when FEATURE_Z_PROBE is off

### DIFF
--- a/src/ArduinoAVR/Repetier/ui.cpp
+++ b/src/ArduinoAVR/Repetier/ui.cpp
@@ -2665,7 +2665,7 @@ int UIDisplay::okAction(bool allowMoves)
             break;
         case UI_ACTION_STATE:
             break;
-#if FEATURE_AUTOLEVEL
+#if FEATURE_AUTOLEVEL & FEATURE_Z_PROBE
         case UI_ACTION_AUTOLEVEL2:
             uid.popMenu(false);
             uid.pushMenu(&ui_msg_calibrating_bed,true);

--- a/src/ArduinoDUE/Repetier/ui.cpp
+++ b/src/ArduinoDUE/Repetier/ui.cpp
@@ -2665,7 +2665,7 @@ int UIDisplay::okAction(bool allowMoves)
             break;
         case UI_ACTION_STATE:
             break;
-#if FEATURE_AUTOLEVEL
+#if FEATURE_AUTOLEVEL & FEATURE_Z_PROBE
         case UI_ACTION_AUTOLEVEL2:
             uid.popMenu(false);
             uid.pushMenu(&ui_msg_calibrating_bed,true);


### PR DESCRIPTION
Hello
I've found a bug while playing with different config parameters.
Couldn't compile sources when FEATURE_Z_PROBE set to 0
Fixed in both platforms. 