### PR TITLE
Update endstops before reasoning about z probe

### DIFF
--- a/src/ArduinoDUE/Repetier/BedLeveling.cpp
+++ b/src/ArduinoDUE/Repetier/BedLeveling.cpp
@@ -576,6 +576,8 @@ float Printer::runZProbe(bool first,bool last,uint8_t repeat,bool runStartScript
         if(r + 1 < repeat) {
             // go only shortest possible move up for repetitions
             PrintLine::moveRelativeDistanceInSteps(0, 0, shortMove, 0, HOMING_FEEDRATE_Z, true, true);
+            Endstops::update();
+            Endstops::update();
             if(Endstops::zProbe()) {
                 Com::printErrorFLN(PSTR("z-probe did not untrigger on repetitive measurement - maybe you need to increase distance!"));
                 UI_MESSAGE(1);
@@ -635,6 +637,8 @@ float Printer::runZProbe(bool first,bool last,uint8_t repeat,bool runStartScript
 #else
     Com::printFLN(Com::tSpaceYColon, realYPosition());
 #endif
+    Endstops::update();
+    Endstops::update();
     if(Endstops::zProbe()) {
         Com::printErrorFLN(PSTR("z-probe did not untrigger after going back to start position."));
         UI_MESSAGE(1);


### PR DESCRIPTION
Hey,

on my delta printer I have to update the endstops before reasoning about the z probe. Otherwise the error message "did not untrigger" is printed though the z probe definitely untriggered (it has a LED and manually checking z probe status returns untriggered as well).
I put it in twice in a row because I found it done this way some lines 547 and 548, but I don't know if it is necessary here.

Would be nice to find this in the official development branch so that I don't have to fix it manually before each update.

Martin