### PR TITLE
UI_ACTION_POWER: UI ATX Power toggle not working

### DIFF
--- a/src/ArduinoDUE/Repetier/ui.cpp
+++ b/src/ArduinoDUE/Repetier/ui.cpp
@@ -3480,9 +3480,11 @@ int UIDisplay::executeAction(unsigned int action, bool allowMoves)
             break;
         case UI_ACTION_POWER:
 #if PS_ON_PIN >= 0 // avoid compiler errors when the power supply pin is disabled
-            Commands::waitUntilEndOfAllMoves();
-            //SET_OUTPUT(PS_ON_PIN); //GND
-            TOGGLE(PS_ON_PIN);
+            {
+              GCode gc; //not fully initialised but processMCode only needs M set for commands 80/81
+              gc.M=Printer::isPowerOn()?81:80;
+              Commands::processMCode(&gc);
+            }
 #endif
             break;
 #if CASE_LIGHTS_PIN >= 0


### PR DESCRIPTION
Call M80/81 which also updates the printer power status

I noticed that UI_ACTION_POWER doesn't seem to work. I could only get it to go in one direction and not back again. I'm guessing TOGGLE does not behave correctly for some reason. I noted that there is also a state member variable which was not being updated. As a work around I called into M80/M81 which does the appropriate processing. Not sure if you will approve of the change as is but could be altered round if not the right way to go. 

Alternatives could be 

- Do the processing in Printer::SetPowerOn and create a toggle function in that class.
- M80/M81 could be factored out somewhere else.
- The change could also be simplified with a constructor in GCode and called as a single line Commands::processMCode(&gc(Printer::isPowerOn()?81:80))