### PR TITLE
Auto power : ENABLE_POWER_ON_STARTUP == 2 only turn on power pin when heat required

### DIFF
--- a/src/ArduinoDUE/Repetier/Configuration.h
+++ b/src/ArduinoDUE/Repetier/Configuration.h
@@ -1260,6 +1260,9 @@ to activate the quadratic term. Only adds lots of computations and storage usage
 /**
 Some boards like Gen7 have a power on pin, to enable the ATX power supply. If this is defined,
 the power will be turned on without the need to call M80 if initially started.
+0 = Do not power on
+1 = Power on startup
+2 = Only power on when heaters / heatbed target temp >= 20 and power off again when heaters & heatbed all off (or on sensor defect)
 */
 #define ENABLE_POWER_ON_STARTUP 1
 

--- a/src/ArduinoDUE/Repetier/Extruder.cpp
+++ b/src/ArduinoDUE/Repetier/Extruder.cpp
@@ -70,6 +70,9 @@ void Extruder::manageTemperatures()
 #ifdef RED_BLUE_STATUS_LEDS
     bool hot = false;
 #endif
+#if defined(ENABLE_POWER_ON_STARTUP) && ENABLE_POWER_ON_STARTUP == 2 && (PS_ON_PIN>-1)
+    bool haveHeatDemand = false;
+#endif // ENABLE_POWER_ON_STARTUP == 2
 	bool newDefectFound = false;
     millis_t time = HAL::timeInMilliseconds(); // compare time for decouple tests
 #if NUM_TEMPERATURE_LOOPS > 0
@@ -78,6 +81,9 @@ void Extruder::manageTemperatures()
         TemperatureController *act = tempController[controller];
         // Get Temperature
         act->updateCurrentTemperature();
+#if defined(ENABLE_POWER_ON_STARTUP) && ENABLE_POWER_ON_STARTUP == 2 && (PS_ON_PIN>-1)
+        haveHeatDemand |= (act->targetTemperatureC >= 20); //PID defines off as < 20
+#endif // ENABLE_POWER_ON_STARTUP == 2
 #if FAN_THERMO_PIN > -1
 		// Special case thermistor controlled fan
         if(act == &thermoController) {
@@ -355,6 +361,21 @@ void Extruder::manageTemperatures()
 		GCode::fatalError(PSTR("Heater/sensor failure"));
     } // any sensor defect
 #endif // NUM_TEMPERATURE_LOOPS
+
+#if defined(ENABLE_POWER_ON_STARTUP) && ENABLE_POWER_ON_STARTUP == 2 && (PS_ON_PIN>-1)
+    if(haveHeatDemand && !Printer::isAnyTempsensorDefect()){
+      if(!Printer::isPowerOn()) {
+        GCode gc; //not fully initialised but processMCode only needs M set for commands 80/81
+        gc.M=80;
+        Commands::processMCode(&gc);
+      }
+    }
+    else if(Printer::isPowerOn()) {
+      GCode gc; //not fully initialised but processMCode only needs M set for commands 80/81
+      gc.M=81;
+      Commands::processMCode(&gc);
+    }
+#endif //ENABLE_POWER_ON_STARTUP == 2
 
     // Report temperatures every second, so we do not need to send M105
     if(Printer::isAutoreportTemp()) {

--- a/src/ArduinoDUE/Repetier/Printer.cpp
+++ b/src/ArduinoDUE/Repetier/Printer.cpp
@@ -963,7 +963,7 @@ void Printer::setup()
 #endif
 #endif
 
-#if defined(ENABLE_POWER_ON_STARTUP) && ENABLE_POWER_ON_STARTUP && (PS_ON_PIN>-1)
+#if defined(ENABLE_POWER_ON_STARTUP) && ENABLE_POWER_ON_STARTUP == 1 && (PS_ON_PIN>-1)
     SET_OUTPUT(PS_ON_PIN); //GND
     WRITE(PS_ON_PIN, (POWER_INVERTING ? HIGH : LOW));
     Printer::setPowerOn(true);


### PR DESCRIPTION
I'm hoping you will merge this low impact change which adds a new safety feature. This is primarily for RAMPS-FD v1 (with inverted heater controls). I have only proposed this on the Due tree as I'm not sure AVR has any boards with inverted heaters. RAMPS-FD v1 is still the only version readily available as of Feb-2017 and this is the most straightforward solution to reduce the risk of any thermal runaway. Changes are isolated with #ifdef and should not have any impact for users who do not require it. ENABLE_POWER_ON_STARTUP == 2 is handled in Extruder::manageTemperatures() and enables / disables the power pin when heat is required and would therefore allow heatbed / hotend power to be isolated via relay or similar method. Please let me know if any changes required to merge.