### PR TITLE
Fix Watchdog reset loop

### DIFF
--- a/src/ArduinoDUE/Repetier/HAL.h
+++ b/src/ArduinoDUE/Repetier/HAL.h
@@ -840,7 +840,9 @@ class HAL
       WDT->WDT_MR = WDT_MR_WDRSTEN | WATCHDOG_INTERVAL | 0x0fff0000; //(WATCHDOG_INTERVAL << 16);
       WDT->WDT_CR = 0xA5000001;
     };
-    inline static void stopWatchdog() {}
+    inline static void stopWatchdog() {
+      WDT_Disable(WDT);
+    }
     inline static void pingWatchdog() {
 #if FEATURE_WATCHDOG
       wdPinged = true;


### PR DESCRIPTION
Stop watchdog implementation in HAL.h is missing from Due side. This can cause a reset loop when hw setup takes a long time such as with 12864LCD.