### PR TITLE
"Fix" DUAL_X_AXIS without LAZY_DUAL_X_AXIS setups.

### DIFF
--- a/src/ArduinoAVR/Repetier/Extruder.cpp
+++ b/src/ArduinoAVR/Repetier/Extruder.cpp
@@ -714,6 +714,13 @@ void Extruder::selectExtruderById(uint8_t extruderId)
 	Com::printFLN(PSTR("SelectExtruder:"), static_cast<int>(extruderId));
 #endif
 
+#if DUAL_X_AXIS
+  //there should be no need to run any more code as the next extruder is already the current one
+  //however for now better restrict this to DUAL_X configurations only as not to break other stuff
+  if (!executeSelect)
+    return;
+#endif
+
 #if NUM_EXTRUDER > 1 && MIXING_EXTRUDER == 0
     if(executeSelect)
     {


### PR DESCRIPTION
doesn't really fix what's wrong in the code, however as the issue happens only when re-selecting current extruder, that code should not run in the first place so returning immediately seems the most logical and clean solution