### PR TITLE
Fix DUAL X with LAZY_DUAL_X_AXIS disabled part 2

### DIFF
--- a/src/ArduinoAVR/Repetier/Extruder.cpp
+++ b/src/ArduinoAVR/Repetier/Extruder.cpp
@@ -714,6 +714,13 @@ void Extruder::selectExtruderById(uint8_t extruderId)
 	Com::printFLN(PSTR("SelectExtruder:"), static_cast<int>(extruderId));
 #endif
 
+#if DUAL_X_AXIS
+  //there should be no need to run any more code as the next extruder is already the current one
+  //however for now better restrict this to DUAL_X configurations only as not to break other stuff
+  if (!executeSelect)
+    return;
+#endif
+
 #if NUM_EXTRUDER > 1 && MIXING_EXTRUDER == 0
     if(executeSelect)
     {

--- a/src/ArduinoDUE/Repetier/Extruder.cpp
+++ b/src/ArduinoDUE/Repetier/Extruder.cpp
@@ -714,6 +714,13 @@ void Extruder::selectExtruderById(uint8_t extruderId)
 	Com::printFLN(PSTR("SelectExtruder:"), static_cast<int>(extruderId));
 #endif
 
+#if DUAL_X_AXIS
+  //there should be no need to run any more code as the next extruder is already the current one
+  //however for now better restrict this to DUAL_X configurations only as not to break other stuff
+  if (!executeSelect)
+    return;
+#endif
+
 #if NUM_EXTRUDER > 1 && MIXING_EXTRUDER == 0
     if(executeSelect)
     {


### PR DESCRIPTION
as remaining issues with dual_x are related to re-selection of current extruder it's better to just skip executing the code. 
To not break any other setup that may still need (altough odd) the old behaviour it's just limited to DUAL_X_AXIS == 1

remade pull request as i forgot DUE files