### PR TITLE
shared PWM budget for extruder and heating bed

### DIFF
--- a/src/ArduinoAVR/Repetier/Configuration.h
+++ b/src/ArduinoAVR/Repetier/Configuration.h
@@ -299,6 +299,20 @@
 #define HEATED_BED_PID_IGAIN   33
 #define HEATED_BED_PID_DGAIN 290
 #define HEATED_BED_PID_MAX 255
+
+/** Shared PWM budget for extruder and heating bed.
+Normally there is not need to run both extruder and heating bed at full power, so some printer 
+vendors may ship printers with underpowered power supplies that can't handle them both 
+simultaneusly. This option is useful for this particular case as it dynamically limits max power
+available to the heating bed if extruder is running. The value should be defined as 
+HEATED_BED_AND_EXTRUDER_PID_MAX = EXT0_PID_MAX + EXT1_PID_MAX + X
+where X is maximum PWM value for heating bed when extruder is also running.
+setting HEATED_BED_AND_EXTRUDER_PID_MAX as HEATED_BED_PID_MAX is a good value to start. It
+could be decreased slowly if power supply continues to shut itself off when extruder and bed and 
+motors all run simultaneously.
+*/
+#define HEATED_BED_AND_EXTRUDER_PID_MAX 0	
+
 #define HEATED_BED_DECOUPLE_TEST_PERIOD 300000
 #define MIN_EXTRUDER_TEMP 150
 #define MAXTEMP 280

--- a/src/ArduinoAVR/Repetier/Extruder.h
+++ b/src/ArduinoAVR/Repetier/Extruder.h
@@ -318,6 +318,9 @@ public:
     void retract(bool isRetract,bool isLong);
     void retractDistance(float dist,bool extraLength = false);
 #endif
+#if HEATED_BED_AND_EXTRUDER_PID_MAX
+static uint8_t dynamicHeatingBedCap(uint8_t pidMax);
+#endif	
     static void manageTemperatures();
     static void disableCurrentExtruderMotor();
     static void disableAllExtruderMotors();


### PR DESCRIPTION
This commit adds a compile time option to add shared PWM budget for heating bed and extruder, which could be useful when printer's power supply can't handle them both at full power at the same time (which is normally not needed anyway). If enabled, this "budget" allows to dynamically cap PID_MAX PWM value for the heating bed when extruder is also powered at the same (if extruder is not powered regular HEATED_BED_PID_MAX value is used)