### PR TITLE
don’t do unnecessary “home – go to z probe distance – home” movements before auto-leveling

### DIFF
--- a/src/ArduinoAVR/Repetier/BedLeveling.cpp
+++ b/src/ArduinoAVR/Repetier/BedLeveling.cpp
@@ -291,7 +291,9 @@ S = 2 : Like s = 1 plus store results in EEPROM for next connection.
 */
 bool runBedLeveling(int s) {
 	bool success = true;
+#if DRIVE_SYSTEM != DELTA
     Printer::prepareForProbing();
+#endif
 #if defined(Z_PROBE_MIN_TEMPERATURE) && Z_PROBE_MIN_TEMPERATURE && Z_PROBE_REQUIRES_HEATING
     float actTemp[NUM_EXTRUDER];
     for(int i = 0; i < NUM_EXTRUDER; i++)

--- a/src/ArduinoDUE/Repetier/BedLeveling.cpp
+++ b/src/ArduinoDUE/Repetier/BedLeveling.cpp
@@ -291,7 +291,9 @@ S = 2 : Like s = 1 plus store results in EEPROM for next connection.
 */
 bool runBedLeveling(int s) {
 	bool success = true;
+#if DRIVE_SYSTEM != DELTA
     Printer::prepareForProbing();
+#endif
 #if defined(Z_PROBE_MIN_TEMPERATURE) && Z_PROBE_MIN_TEMPERATURE && Z_PROBE_REQUIRES_HEATING
     float actTemp[NUM_EXTRUDER];
     for(int i = 0; i < NUM_EXTRUDER; i++)


### PR DESCRIPTION
for delta printers when doing G32 auto-levelling, it'll first run Printer::prepareForProbing(), which homes all axes and then goes down to the z-probe bed distance. however, it'll then home again due to unconditional homing in line 329, which repeats those motions unnecessarily.

as a fix, I'd suggest removing the call to Printer::prepareForProbing() for delta printers, since it doesn't do anything besides those movements. alternatively, either instance of the homing/go-to-z-probe-distance movements can be removed from either prepareForProbing() or runBedLevelling() – I'm not sure which is the ideal solution.