### PR TITLE
use Z_PROBE_SPEED instead of HOMING_FEEDRATE_Z to go up for z-probe repetitions

### DIFF
--- a/src/ArduinoAVR/Repetier/BedLeveling.cpp
+++ b/src/ArduinoAVR/Repetier/BedLeveling.cpp
@@ -657,7 +657,7 @@ float Printer::runZProbe(bool first, bool last, uint8_t repeat, bool runStartScr
         //Com::printFLN(PSTR("ZHSteps:"),lastCorrection - currentPositionSteps[Z_AXIS]);
         if(r + 1 < repeat) {
             // go only shortest possible move up for repetitions
-            PrintLine::moveRelativeDistanceInSteps(0, 0, shortMove, 0, HOMING_FEEDRATE_Z, true, true);
+            PrintLine::moveRelativeDistanceInSteps(0, 0, shortMove, 0, Z_PROBE_SPEED, true, true);
             if(Endstops::zProbe()) {
                 Com::printErrorFLN(PSTR("z-probe did not untrigger on repetitive measurement - maybe you need to increase distance!"));
                 UI_MESSAGE(1);

--- a/src/ArduinoDUE/Repetier/BedLeveling.cpp
+++ b/src/ArduinoDUE/Repetier/BedLeveling.cpp
@@ -657,7 +657,7 @@ float Printer::runZProbe(bool first, bool last, uint8_t repeat, bool runStartScr
         //Com::printFLN(PSTR("ZHSteps:"),lastCorrection - currentPositionSteps[Z_AXIS]);
         if(r + 1 < repeat) {
             // go only shortest possible move up for repetitions
-            PrintLine::moveRelativeDistanceInSteps(0, 0, shortMove, 0, HOMING_FEEDRATE_Z, true, true);
+            PrintLine::moveRelativeDistanceInSteps(0, 0, shortMove, 0, Z_PROBE_SPEED, true, true);
             if(Endstops::zProbe()) {
                 Com::printErrorFLN(PSTR("z-probe did not untrigger on repetitive measurement - maybe you need to increase distance!"));
                 UI_MESSAGE(1);


### PR DESCRIPTION
Currently, HOMING_FEEDRATE_Z is used as speed to retract the nozzle/z-probe between multiple probing repetitions.

However, if a vibration sensitive Z probe is used (such as a piezo sensor) on a delta with a fast Z homing feedrate, the short motion can well fall within the Z_JERK limit, causing an inadvertent triggering of the z-probe at the end of the move due to the momentum of the extruder. Repetier will then trigger an error because it reports the Z probe as not having properly untriggered after moving to back to the probe rest position.

I'd suggest doing this move at Z_PROBE_SPEED instead, since the slower feed rate doesn't really matter at such short distances, and Cartesian printers have a slow Z max. speed anyway. Alternatively, another setting could be introduced, but I think this is a viable compromise.