### PR TITLE
Update makefile subsystem for ArduinoAVR stand alone make for all versions of Arduino

### DIFF
--- a/src/ArduinoAVR/Repetier/.gitignore
+++ b/src/ArduinoAVR/Repetier/.gitignore
@@ -1,3 +1,5 @@
 applet
 arduino.lib
 ard.all
+fake_new_delete.c
+fake_new_delete.h

--- a/src/ArduinoAVR/Repetier/Makefile
+++ b/src/ArduinoAVR/Repetier/Makefile
@@ -79,7 +79,8 @@ $(ARDUINO)/WString.cpp
 
 # Name of this Makefile (used for "make depend").
 MAKEFILE = Makefile
-GCC_WORKAROUND=$(shell _v=$$($(CC) --version|grep GCC|sed 's!.* !!'|tr -d '.'); let v=_v; if [ $$v -ge 480 ]; then echo "0"; else echo "1"; fi )
+GCC_VER=$(shell $(CC) --version|grep GCC|sed 's!.* !!'|tr -d '.' )
+GCC_WORKAROUND=$(shell if [ $(GCC_VER) -ge 480 ]; then echo "0"; else echo "1"; fi 2>/dev/null)
 # Debugging format.
 # Native formats for AVR-GCC's -g are stabs [default], or dwarf-2.
 # AVR (extended) COFF requires stabs, plus an avr-objcopy run.
@@ -242,6 +243,7 @@ fake_new_delete.o: fake_new_delete.c
 
 	# Link: create ELF output file from library.
 applet/$(TARGET).elf: $(PDEFILE) applet/core.a fake_new_delete.o
+	@echo "GCC_VER=$(GCC_VER) GCC_W=$(GCC_WORKAROUND)"
 	$(CXX) $(ALL_CXXFLAGS) -o $@ applet/$(TARGET).cpp -L. applet/core.a fake_new_delete.o $(LDFLAGS) 
 	$(ELFSIZE)
 

--- a/src/ArduinoAVR/Repetier/Makefile
+++ b/src/ArduinoAVR/Repetier/Makefile
@@ -80,7 +80,6 @@ $(ARDUINO)/WString.cpp
 # Name of this Makefile (used for "make depend").
 MAKEFILE = Makefile
 GCC_VER=$(shell $(CC) --version|grep GCC|sed 's!.* !!'|tr -d '.' )
-GCC_WORKAROUND=$(shell if [ $(GCC_VER) -ge 480 ]; then echo "0"; else echo "1"; fi 2>/dev/null)
 # Debugging format.
 # Native formats for AVR-GCC's -g are stabs [default], or dwarf-2.
 # AVR (extended) COFF requires stabs, plus an avr-objcopy run.
@@ -111,11 +110,6 @@ CFLAGS = $(CDEBUG) $(CDEFS) $(CINCS) -O$(OPT) $(CWARN) $(CSTANDARD) $(CEXTRA) -M
 CXXFLAGS = $(CDEFS) $(CINCS) -O$(OPT) -MD -MP -D$(ARDUINO_VER)
 #ASFLAGS = -Wa,-adhlns=$(<:.S=.lst),-gstabs 
 #LDFLAGS = -lm -lC -Wl,-Map=applet/$(TARGET).map
-ifeq ($(GCC_WORKAROUND),1)
-LDFLAGS = -lm -lc -Wl,-Map=applet/$(TARGET).map -lc
-else
-LDFLAGS = -lm -Wl,-Map=applet/$(TARGET).map
-endif
 
 # Programming support using avrdude. Settings and variables.
 AVRDUDE_PORT = $(PORT)
@@ -125,7 +119,7 @@ AVRDUDE_FLAGS = -D -C $(AVRDUDE_CONF) \
 #-b $(UPLOAD_RATE)
 
 # Program settings
-CC = $(AVR_TOOLS_PATH)/avr-gcc
+CC := $(AVR_TOOLS_PATH)/avr-gcc
 CXX = $(AVR_TOOLS_PATH)/avr-g++
 OBJCOPY = $(AVR_TOOLS_PATH)/avr-objcopy
 OBJDUMP = $(AVR_TOOLS_PATH)/avr-objdump
@@ -139,6 +133,13 @@ REMOVE = rm -f
 MV = mv -f
 
 VPATH=.
+
+GCC_WORKAROUND:=$(shell $(CC) --version|grep GCC|sed 's!.* !!'|tr -d '.'|sed 's!$$!<480!'|bc)
+ifeq ($(GCC_WORKAROUND),1)
+LDFLAGS = -lm -lc -Wl,-Map=applet/$(TARGET).map -lc
+else
+LDFLAGS = -lm -Wl,-Map=applet/$(TARGET).map
+endif
 # Define all object files.
 OBJ = $(SRC:.c=.o) $(CXXSRC:.cpp=.o) $(ASRC:.S=.o) 
 

--- a/src/ArduinoAVR/Repetier/Makefile
+++ b/src/ArduinoAVR/Repetier/Makefile
@@ -79,7 +79,7 @@ $(ARDUINO)/WString.cpp
 
 # Name of this Makefile (used for "make depend").
 MAKEFILE = Makefile
-
+GCC_WORKAROUND=$(shell _v=$$($(CC) --version|grep GCC|sed 's!.* !!'|tr -d '.'); let v=_v; if [ $$v -ge 480 ]; then echo "0"; else echo "1"; fi )
 # Debugging format.
 # Native formats for AVR-GCC's -g are stabs [default], or dwarf-2.
 # AVR (extended) COFF requires stabs, plus an avr-objcopy run.
@@ -110,8 +110,11 @@ CFLAGS = $(CDEBUG) $(CDEFS) $(CINCS) -O$(OPT) $(CWARN) $(CSTANDARD) $(CEXTRA) -M
 CXXFLAGS = $(CDEFS) $(CINCS) -O$(OPT) -MD -MP -D$(ARDUINO_VER)
 #ASFLAGS = -Wa,-adhlns=$(<:.S=.lst),-gstabs 
 #LDFLAGS = -lm -lC -Wl,-Map=applet/$(TARGET).map
+ifeq ($(GCC_WORKAROUND),1)
+LDFLAGS = -lm -lc -Wl,-Map=applet/$(TARGET).map -lc
+else
 LDFLAGS = -lm -Wl,-Map=applet/$(TARGET).map
-
+endif
 
 # Programming support using avrdude. Settings and variables.
 AVRDUDE_PORT = $(PORT)

--- a/src/ArduinoAVR/Repetier/Makefile
+++ b/src/ArduinoAVR/Repetier/Makefile
@@ -32,6 +32,7 @@
 #
 # $Id$
 
+ARDUINO_TAG?=1.0.5
 #TARGET = $(notdir $(CURDIR))
 FORMAT:=ihex
 TARGET = Repetier
@@ -64,16 +65,22 @@ F_CPU = 16000000
 # look in core/usr/share/arduino/revisions.txt, use ARDUINO def from there
 ARDUINO_VER = ARDUINO=105
 ARDUINO = arduino.lib
+
+HW_SER1:=$(shell echo "$(ARDUINO_TAG)"|tr -d '.'|sed 's!$$!>165!'|bc)
+ifeq ($(HW_SER1),1)
+HW_SER1_SRC:=$(ARDUINO)/HardwareSerial1.cpp $(ARDUINO)/HardwareSerial0.cpp
+HW_C_SRC:=$(ARDUINO)/hooks.c
+endif
+
 AVR_TOOLS_PATH = /usr/bin
 #AVR_TOOLS_PATH = d:/WinAVR/bin
 SRC =  $(ARDUINO)/pins_arduino.c $(ARDUINO)/wiring.c \
 $(ARDUINO)/wiring_analog.c $(ARDUINO)/wiring_digital.c \
-$(ARDUINO)/wiring_pulse.c \
+$(ARDUINO)/wiring_pulse.c $(HW_C_SRC)\
 $(ARDUINO)/wiring_shift.c $(ARDUINO)/WInterrupts.c 
 CXXSRC = $(ARDUINO)/HardwareSerial.cpp $(ARDUINO)/WMath.cpp \
 $(ARDUINO)/Print.cpp  $(shell ls *.cpp) \
-$(ARDUINO)/WString.cpp
-
+$(ARDUINO)/WString.cpp $(HW_SER1_SRC)
 #$(ARDUINO)/Print.cpp ./SdFile.cpp ./SdVolume.cpp ./Sd2Card.cpp ./gcode.cpp \
 
 
@@ -151,22 +158,30 @@ LST = $(ASRC:.S=.lst) $(CXXSRC:.cpp=.lst) $(SRC:.c=.lst)
 ALL_CFLAGS = -mmcu=$(MCU) -I. $(CFLAGS)
 ALL_CXXFLAGS = -mmcu=$(MCU) -I. $(CXXFLAGS)
 ALL_ASFLAGS = -mmcu=$(MCU) -I. -x assembler-with-cpp $(ASFLAGS)
-
+RELIB?=0
 help:
-	@echo "Targets are build, sizeafter, and upload"
+	@echo "Targets are build, clean, cleanall, sizeafter, and upload"
 	@echo "for upload, set PORT for the serial terminal"
 	@echo " ex: make PORT=$(PORT) upload"
+	@echo " to use a different ARDUINO tag, set ARDUINO_TAG to tag, i.e. ARDUINO_TAG=$(ARDUINO_TAG)"
+	@echo " Set RELIB to just check out a differene ARDUINO tag and rebuild"
 
 # Default target.
 all:  build sizeafter
-
+ifeq ($(RELIB),1)
+build: cleanlib
+endif
 build: applet/$(TARGET).cpp elf hex lss
 
 applet:
 	mkdir $@
 
 $(ARDUINO):
-	./get_arduino_libs.sh
+ifeq ($(RELIB),1)
+	./get_arduino_libs.sh $(ARDUINO_TAG) 1
+else
+	./get_arduino_libs.sh $(ARDUINO_TAG) 
+endif
 
 fake_new_delete.c fake_new_delete.h:
 	./build_fake_cplus.sh 
@@ -278,6 +293,12 @@ clean:
 	$(REMOVE) -r applet $(OBJ) $(LST) $(SRC:.c=.s) $(SRC:.c=.d) $(CXXSRC:.cpp=.s) $(CXXSRC:.cpp=.d) 
 	$(REMOVE) fake_new_delete*
 
+cleanlib: clean
+	$(REMOVE) -r arduino.lib
+
+cleanall: clean cleanlib
+	$(REMOVE) -r   ard.all
+
 depend:
 	if grep '^# DO NOT DELETE' $(MAKEFILE) >/dev/null; \
 	then \
@@ -289,4 +310,4 @@ depend:
 		>> $(MAKEFILE); \
 	$(CC) -M -mmcu=$(MCU) $(CDEFS) $(CINCS) $(SRC) $(ASRC) >> $(MAKEFILE)
 
-.PHONY:	all build elf hex eep lss sym program coff extcoff clean depend applet_files sizebefore sizeafter
+.PHONY:	all build elf hex eep lss sym program coff extcoff clean cleanlib cleanall depend applet_files sizebefore sizeafter

--- a/src/ArduinoAVR/Repetier/get_arduino_libs.sh
+++ b/src/ArduinoAVR/Repetier/get_arduino_libs.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+ARD_VER="1.0.5"
+LAST_OLD="1.0.6"
+
+#Which struct we use
+
 # This is to get the files we need from Arduino to build.
 URL="https://github.com/arduino/Arduino.git"
 # backup
@@ -13,15 +18,15 @@ clone_arduino () {
 		exit 1
 	fi
 	cd ard.all
-	git checkout 1.0.5
+	git checkout $ARD_VER
 	cd ..
 }
 # Grab the 236M beastie
 get_arduino_tag () {
-	wget -O ard.zip 'https://github.com/arduino/Arduino/archive/1.0.5.zip'
+	wget -O ard.zip "https://github.com/arduino/Arduino/archive/$ARD_VER.zip"
 	# unzips to Arduino-1.0.5
 	unzip ard.zip
-	idir="Arduino-1.0.5"
+	idir="Arduino-$ARD_VER"
 }
 # Just get the few files we need. 
 get_short_arduino_libs() {
@@ -33,9 +38,23 @@ mkdir $odir
 #latest version paths:
 #cp ard.all/hardware/arduino/avr/cores/arduino/* $odir
 #cp ard.all/hardware/arduino/avr/variants/mega/* $odir
+#cp ard.all/hardware/arduino/avr/libraries/SPI/src/* $odir
+L=$(echo "$LAST_OLD"|tr -d '.')
+A=$(echo "$ARD_VER"|tr -d '.')
+let l=L
+let a=A
+if [ $a -gt $l ]; then
+	PA="ard.all/hardware/arduino/avr/cores/arduino"
+	PM="ard.all/hardware/arduino/avr/variants/mega"
+	PS="ard.all/hardware/arduino/avr/libraries/SPI/src/SPI.h"
+else
+	PA="ard.all/hardware/arduino/cores/arduino"
+	PM="ard.all/hardware/arduino/variants/mega"
+	PS="ard.all/libraries/SPI/SPI.h"
+fi
 
-cp -a ard.all/hardware/arduino/cores/arduino/* $odir
-cp ard.all/hardware/arduino/variants/mega/* $odir
-cp ard.all/libraries/SPI/SPI.h $odir 
+cp -a $PA/* $odir
+cp $PM/* $odir
+cp $PS $odir 
 echo '#include "pins_arduino.h"' > $odir/pins_arduino.c
 

--- a/src/ArduinoAVR/Repetier/get_arduino_libs.sh
+++ b/src/ArduinoAVR/Repetier/get_arduino_libs.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
-ARD_VER="1.0.5"
-LAST_OLD="1.0.6"
+# Version of Arduino we want to build against. 1.0.5 is known to work.
+ARD_VER="1.0.6"
 
+# Do not change the variables below. 
+# These mark the point where the directory structure changed.
+LAST_OLD="1.0.6"
+SPI_SRC="1.6.8"
+
+if [ -n "$1" ]; then
+	ARD_VER="$1"
+fi
+RE_CHECK=0
+if [ -n "$2" ]; then # they want to check out another tag, just do the copy.
+	RE_CHECK=1
+fi
 #Which struct we use
 
 # This is to get the files we need from Arduino to build.
@@ -30,10 +42,22 @@ get_arduino_tag () {
 }
 # Just get the few files we need. 
 get_short_arduino_libs() {
-	URL="https://github.com/rickyrockrat/arduino_short.git"
+	#URL="https://github.com/rickyrockrat/arduino_short.git"
+	URL="https://github.com/rickyrockrat/Arduino.hardware.git"
 	clone_arduino
 }
-get_short_arduino_libs
+if [ "1" = "$RE_CHECK" ]; then
+	rm -rf "$odir"
+	if [ ! -e "$idir" ]; then
+		get_short_arduino_libs
+	else
+		cd ard.all
+		git checkout $ARD_VER
+		cd ..
+	fi
+else
+	get_short_arduino_libs
+fi
 mkdir $odir
 #latest version paths:
 #cp ard.all/hardware/arduino/avr/cores/arduino/* $odir
@@ -41,12 +65,20 @@ mkdir $odir
 #cp ard.all/hardware/arduino/avr/libraries/SPI/src/* $odir
 L=$(echo "$LAST_OLD"|tr -d '.')
 A=$(echo "$ARD_VER"|tr -d '.')
+S=$(echo "$SPI_SRC"|tr -d '.')
+
 let l=L
 let a=A
+let s=S
+
 if [ $a -gt $l ]; then
 	PA="ard.all/hardware/arduino/avr/cores/arduino"
 	PM="ard.all/hardware/arduino/avr/variants/mega"
-	PS="ard.all/hardware/arduino/avr/libraries/SPI/src/SPI.h"
+	if [ $a -ge $s ]; then 
+		PS="ard.all/hardware/arduino/avr/libraries/SPI/src/SPI.h"
+	else
+		PS="ard.all/hardware/arduino/avr/libraries/SPI/SPI.h"
+	fi
 else
 	PA="ard.all/hardware/arduino/cores/arduino"
 	PM="ard.all/hardware/arduino/variants/mega"


### PR DESCRIPTION
This is an update to the last push that now supports both old and new avr-gcc compilers, and supports 1.0.5 through 1.8.4 versions of Arduino, and updates the sparse Arduino clone URL.