### PR TITLE
Update pins.h

### DIFF
--- a/src/ArduinoDUE/Repetier/pins.h
+++ b/src/ArduinoDUE/Repetier/pins.h
@@ -330,7 +330,6 @@ STEPPER_CURRENT_CONTROL
 #define SDSS		   4 
 //#define SDSS		   -1
 //#define ORIG_SDCARDDETECT   -1
-#define SDCARDDETECTINVERTED false
 #define LED_PIN 	   -1
 #define ORIG_FAN_PIN 	   12 
 #define ORIG_FAN2_PIN       2


### PR DESCRIPTION
there is no SD on RAMPS-FD
  #define SDCARDDETECTINVERTED false 
generates only unnecessary warnings because it is repeated in configuration.h