### PR TITLE
Remove IDE files from codebase and mark them ignored in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ src/ArduinoDUE/Repetier.zip
 src/ArduinoAVR/Repetier.zip
 
 workspace.xml
+.idea/*

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding">
-    <file url="PROJECT" charset="UTF-8" />
-  </component>
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/repetier-firmware-work.iml" filepath="$PROJECT_DIR$/.idea/repetier-firmware-work.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/repetier-firmware-work.iml
+++ b/.idea/repetier-firmware-work.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
Hey there,

This change removes the `.idea/` directory used by Jetbrains products.  This was causing issues in my my IDE (IntelliJ on macOS) when I opened it because some paths were different.   I expect this was accidentally checked in at some point and I've added it to the `.gitignore` as well.    

This should have no change to the firmware or to any existing dev environments. 

Thank you for all your work!  