### PR TITLE
TMC2130 Diagnostic Reading with M122 command

### DIFF
--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -638,6 +638,297 @@ void motorCurrentReadings() {
 }
 #endif // CURRENT_CONTROL_TMC2130
 
+#if defined(DRV_TMC2130)
+// Define a struct for all available TMC2130 drivers and their (axis/extruder) names.
+static struct struct_tmc2130_drivers {
+  FSTRINGPARAM(name);
+  TMC2130Stepper **driver;
+} tmc2130_drivers[] = {
+#if TMC2130_ON_X
+  {Com::tXColon, &Printer::tmc_driver_x},
+#endif
+#if TMC2130_ON_Y
+  {Com::tYColon, &Printer::tmc_driver_y},
+#endif
+#if TMC2130_ON_Z
+  {Com::tZColon, &Printer::tmc_driver_z},
+#endif
+#if TMC2130_ON_EXT0
+  {Com::tE0Colon, &Printer::tmc_driver_e0},
+#endif
+#if TMC2130_ON_EXT1
+  {Com::tE1Colon, &Printer::tmc_driver_e1},
+#endif
+#if TMC2130_ON_EXT2
+  {Com::tE2Colon, &Printer::tmc_driver_e2},
+#endif
+  {NULL, NULL}
+};
+
+
+void tmc2130DiagnosticReadingSingleDriverLineName(uint8_t line) {
+  switch (line) {
+    case 0:
+      Com::printF(PSTR("\t"));
+      break;
+    case 1:
+      Com::printF(Com::tEnabledColon);
+      break;
+    case 2:
+      Com::printF(Com::tSetCurrentColon);
+      break;
+    case 3:
+      Com::printF(Com::tRMSCurrentColon);
+      break;
+    case 4:
+      Com::printF(Com::tMaxCurrentColon);
+      break;
+    case 5:
+      Com::printF(Com::tRunCurrentColon);
+      break;
+    case 6:
+      Com::printF(Com::tHoldCurrentColon);
+      break;
+    case 7:
+      Com::printF(Com::tCSActualColon);
+      break;
+    case 8:
+      Com::printF(Com::tPWMScaleColon);
+      break;
+    case 9:
+      Com::printF(Com::tVSENSEColon);
+      break;
+    case 10:
+      Com::printF(Com::tStealthchopColon);
+      break;
+    case 11:
+      Com::printF(Com::tMicrostepsColon);
+      break;
+    case 12:
+      Com::printF(Com::tTSTEPColon);
+      break;
+    case 13:
+      Com::printF(Com::tPWMThresholdColon);
+      break;
+    case 14:
+      Com::printF(Com::tOTPrewarnColon);
+      break;
+    case 15:
+      Com::printF(Com::tOTTriggeredColon);
+      break;
+    case 16:
+      Com::printF(Com::tOffTimeColon);
+      break;
+    case 17:
+      Com::printF(Com::tBlankTimeColon);
+      break;
+    case 18:
+      Com::printF(Com::tHystEndColon);
+      break;
+    case 19:
+      Com::printF(Com::tHystStartColon);
+      break;
+    case 20:
+      Com::printF(Com::tStallGuardThrColon);
+      break;
+    case 21:
+      Com::printF(Com::tDriverStatus);
+      break;
+    case 22:
+      Com::printF(Com::tPlusStallGuardColon);
+      break;
+    case 23:
+      Com::printF(Com::tPlusSGResultColon);
+      break;
+    case 24:
+      Com::printF(Com::tPlusFSActiveColon);
+      break;
+    case 25:
+      Com::printF(Com::tPlusSTSTColon);
+      break;
+    case 26:
+      Com::printF(Com::tPlusOLBColon);
+      break;
+    case 27:
+      Com::printF(Com::tPlusOLAColon);
+      break;
+    case 28:
+      Com::printF(Com::tPlusS2GBColon);
+      break;
+    case 29:
+      Com::printF(Com::tPlusS2GAColon);
+      break;
+    case 30:
+      Com::printF(Com::tPlusOTPWColon);
+      break;
+    case 31:
+      Com::printF(Com::tPlusOTColon);
+      break;
+  }
+}
+
+void tmc2130DiagnosticReadingSingleDriverLineValue(uint8_t line, TMC2130Stepper* tmc) {
+  switch (line) {
+    case 1:
+      if (tmc->isEnabled())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 2:
+      Com::printNumber(tmc->getCurrent());
+      break;
+    case 3:
+      Com::printNumber(tmc->rms_current());
+      break;
+    case 4:
+      Com::printFloat((float)tmc->rms_current()*1.41, 0);
+      break;
+    case 5:
+      Com::printNumber(tmc->irun()+1);
+      Com::printF(Com::tDiv32);
+      break;
+    case 6:
+      Com::printNumber(tmc->ihold()+1);
+      Com::printF(Com::tDiv32);
+      break;
+    case 7:
+      Com::printNumber(tmc->cs_actual()+1);
+      Com::printF(Com::tDiv32);
+      break;
+    case 8:
+      Com::printNumber(tmc->PWM_SCALE());
+      break;
+    case 9:
+      if  (tmc->vsense())
+        Com::printFloat(0.18f,3);
+      else
+        Com::printFloat(0.325f, 3);
+      break;
+    case 10:
+      if (tmc->stealthChop())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 11:
+      Com::printNumber(tmc->microsteps());
+      break;
+    case 12:
+      Com::printNumber(tmc->TSTEP());
+      break;
+    case 13:
+      Com::printNumber(tmc->TPWMTHRS());
+      break;
+    case 14:
+      if (tmc->otpw())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 15:
+      if (tmc->getOTPW())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 16:
+      Com::printNumber(tmc->toff());
+      break;
+    case 17:
+      Com::printNumber(tmc->blank_time());
+      break;
+    case 18:
+      Com::print(tmc->hysteresis_end());
+      break;
+    case 19:
+      Com::printNumber(tmc->hysteresis_start());
+      break;
+    case 20:
+      Com::printNumber(tmc->sgt());
+      break;
+    case 21:
+      // blank by purpose
+      break;
+    case 22:
+      if (tmc->stallguard())
+        Com::printF(Com::tCross);
+      break;
+    case 23:
+      Com::printNumber(tmc->sg_result());
+      break;
+    case 24:
+      if (tmc->fsactive())
+        Com::printF(Com::tCross);
+      break;
+    case 25:
+      if (tmc->stst())
+        Com::printF(Com::tCross);
+      break;
+    case 26:
+      if (tmc->olb())
+        Com::printF(Com::tCross);
+      break;
+    case 27:
+      if (tmc->ola())
+        Com::printF(Com::tCross);
+      break;
+    case 28:
+      if (tmc->s2gb())
+        Com::printF(Com::tCross);
+      break;
+    case 29:
+      if (tmc->s2ga())
+        Com::printF(Com::tCross);
+      break;
+    case 30:
+      if (tmc->otpw())
+        Com::printF(Com::tCross);
+      break;
+    case 31:
+      if (tmc->ot())
+        Com::printF(Com::tCross);
+      break;
+    default:
+      Com::printF(PSTR("?"));
+      break;
+  }
+}
+
+void tmc2130DiagnosticReadingSingleDriver(FSTRINGPARAM(text), TMC2130Stepper *tmc) {
+  Com::printF(text);
+  Com::println();
+  Com::printF(Com::tSpace);
+  Com::printHexNumber(tmc->DRV_STATUS());
+  Com::println();
+}
+
+void tmc2130DiagnosticReadings() {
+  struct struct_tmc2130_drivers *drv = tmc2130_drivers;
+  Com::printFLN(Com::tTrinamic2130DiagnosticReadings);
+  tmc2130DiagnosticReadingSingleDriverLineName(0);
+  for (uint8_t idx=0; tmc2130_drivers[idx].driver != NULL; idx++) {
+    Com::printF(PSTR("\t"));
+    Com::printF(tmc2130_drivers[idx].name);
+  }
+  Com::println();
+  for (uint8_t i=1; i<=31; i++) {
+    tmc2130DiagnosticReadingSingleDriverLineName(i);
+    for (uint8_t idx=0; tmc2130_drivers[idx].driver != NULL; idx++) {
+      Com::printF(PSTR("\t"));
+      tmc2130DiagnosticReadingSingleDriverLineValue(i, *(tmc2130_drivers[idx].driver));
+    }
+    Com::println();
+  }
+  for (uint8_t idx=0; tmc2130_drivers[idx].driver != NULL; idx++) {
+    Com::printF(tmc2130_drivers[idx].name);
+    Com::printF(PSTR("\t"));
+    Com::printHexNumber((*(tmc2130_drivers[idx].driver))->DRV_STATUS());
+    Com::println();
+  }
+}
+#endif
+
 #if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
 uint8_t _intVref[] = { MCP4728_VREF, MCP4728_VREF, MCP4728_VREF, MCP4728_VREF };
 uint8_t _gain[] = { MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN };
@@ -2322,6 +2613,11 @@ void Commands::processMCode(GCode* com) {
     case 120: // M120 Test beeper function
         if (com->hasS() && com->hasP())
             beep(com->S, com->P); // Beep test
+        break;
+#endif
+#if defined(DRV_TMC2130)
+    case 122: // M122 TMC2130 diagnostic function
+        tmc2130DiagnosticReadings();
         break;
 #endif
 #if MIXING_EXTRUDER > 0

--- a/src/ArduinoAVR/Repetier/Communication.cpp
+++ b/src/ArduinoAVR/Repetier/Communication.cpp
@@ -140,6 +140,7 @@ FSTRINGVALUE(Com::tYColon, "Y:")
 FSTRINGVALUE(Com::tZColon, "Z:")
 FSTRINGVALUE(Com::tE0Colon, "E0:")
 FSTRINGVALUE(Com::tE1Colon, "E1:")
+FSTRINGVALUE(Com::tE2Colon, "E2:")
 FSTRINGVALUE(Com::tMS1MS2Pins, "MS1,MS2 Pins")
 FSTRINGVALUE(Com::tSetOutputSpace, "Set output: ")
 FSTRINGVALUE(Com::tGetInputSpace, "Get Input: ")
@@ -500,6 +501,42 @@ FSTRINGVALUE(Com::tStartupGCode, STARTUP_GCODE)
 #ifdef DRV_TMC2130
 FSTRINGVALUE(Com::tTrinamicMotorCurrent, "Trinamic motor current:")
 FSTRINGVALUE(Com::tTrinamicMicrostepMode, "Trinamic microstep mode:")
+FSTRINGVALUE(Com::tTrinamic2130DiagnosticReadings, "Trinamic 2130 diagnostic readings:")
+FSTRINGVALUE(Com::tTrue, "True");
+FSTRINGVALUE(Com::tFalse, "False");
+FSTRINGVALUE(Com::tDiv32, "/32");
+FSTRINGVALUE(Com::tCross, "X");
+FSTRINGVALUE(Com::tEnabledColon,        "Enabled:")
+FSTRINGVALUE(Com::tSetCurrentColon,     "Set current:")
+FSTRINGVALUE(Com::tRMSCurrentColon,     "RMS current:")
+FSTRINGVALUE(Com::tMaxCurrentColon,     "Max current:")
+FSTRINGVALUE(Com::tRunCurrentColon,     "Run current:")
+FSTRINGVALUE(Com::tHoldCurrentColon,    "Hold current:")
+FSTRINGVALUE(Com::tCSActualColon,       "CS actual:")
+FSTRINGVALUE(Com::tPWMScaleColon,       "PWM scale:")
+FSTRINGVALUE(Com::tVSENSEColon,         "VSENSE:\t")
+FSTRINGVALUE(Com::tStealthchopColon,    "Stealthchop:")
+FSTRINGVALUE(Com::tMicrostepsColon,     "Microsteps:")
+FSTRINGVALUE(Com::tTSTEPColon,          "TSTEP:\t")
+FSTRINGVALUE(Com::tPWMThresholdColon,   "PWM threshold:")
+FSTRINGVALUE(Com::tOTPrewarnColon,      "OT prewarn:")
+FSTRINGVALUE(Com::tOTTriggeredColon,    "OT triggered:")
+FSTRINGVALUE(Com::tOffTimeColon,        "Off time:")
+FSTRINGVALUE(Com::tBlankTimeColon,      "Blank time:")
+FSTRINGVALUE(Com::tHystEndColon,        "Hyst. end:")
+FSTRINGVALUE(Com::tHystStartColon,      "Hyst. start:")
+FSTRINGVALUE(Com::tStallGuardThrColon,  "StallGuard thr:")
+FSTRINGVALUE(Com::tDriverStatus,   "Driver Status")
+FSTRINGVALUE(Com::tPlusStallGuardColon, "+ StallGuard:")
+FSTRINGVALUE(Com::tPlusSGResultColon,   "+ sg_result:")
+FSTRINGVALUE(Com::tPlusFSActiveColon,   "+ fsactive:")
+FSTRINGVALUE(Com::tPlusSTSTColon,       "+ stst:\t")
+FSTRINGVALUE(Com::tPlusOLBColon,        "+ olb:\t")
+FSTRINGVALUE(Com::tPlusOLAColon,        "+ ola:\t")
+FSTRINGVALUE(Com::tPlusS2GBColon,       "+ s2gb:\t")
+FSTRINGVALUE(Com::tPlusS2GAColon,       "+ s2ga:\t")
+FSTRINGVALUE(Com::tPlusOTPWColon,       "+ otpw:\t")
+FSTRINGVALUE(Com::tPlusOTColon,         "+ ot:\t")
 #endif
 bool Com::writeToAll = true; // transmit start messages to all devices!
 
@@ -671,6 +708,26 @@ void Com::printNumber(uint32_t n)
 
   print(str);
 }
+
+void Com::printHexNumber(uint32_t n)
+{
+  char buf[11]; // Assumes 8-bit chars plus zero byte.
+  char *str = &buf[10];
+  buf[0] = '0';
+  buf[1] = 'x';
+  buf[10] = '\0';
+  do
+  {
+    uint8_t nibble = n&0x0F;
+    if (nibble > 9)
+      *--str = 'A'+(nibble-0xA);
+    else
+      *--str = '0'+nibble;
+    n>>=4;
+  } while (str != &buf[2]);
+  print(buf);
+}
+
 void Com::printArrayFLN(FSTRINGPARAM(text), float *arr, uint8_t n,
                         uint8_t digits)
 {

--- a/src/ArduinoAVR/Repetier/Communication.h
+++ b/src/ArduinoAVR/Repetier/Communication.h
@@ -176,6 +176,7 @@ public:
   FSTRINGVAR(tZColon)
   FSTRINGVAR(tE0Colon)
   FSTRINGVAR(tE1Colon)
+  FSTRINGVAR(tE2Colon)
   FSTRINGVAR(tMS1MS2Pins)
   FSTRINGVAR(tSetOutputSpace)
   FSTRINGVAR(tGetInputSpace)
@@ -490,6 +491,42 @@ public:
 #ifdef DRV_TMC2130
   FSTRINGVAR(tTrinamicMotorCurrent)
   FSTRINGVAR(tTrinamicMicrostepMode)
+  FSTRINGVAR(tTrinamic2130DiagnosticReadings)
+  FSTRINGVAR(tTrue)
+  FSTRINGVAR(tFalse)
+  FSTRINGVAR(tDiv32)
+  FSTRINGVAR(tCross)
+  FSTRINGVAR(tEnabledColon)
+  FSTRINGVAR(tSetCurrentColon)
+  FSTRINGVAR(tRMSCurrentColon)
+  FSTRINGVAR(tMaxCurrentColon)
+  FSTRINGVAR(tRunCurrentColon)
+  FSTRINGVAR(tHoldCurrentColon)
+  FSTRINGVAR(tCSActualColon)
+  FSTRINGVAR(tPWMScaleColon)
+  FSTRINGVAR(tVSENSEColon)
+  FSTRINGVAR(tStealthchopColon)
+  FSTRINGVAR(tMicrostepsColon)
+  FSTRINGVAR(tTSTEPColon)
+  FSTRINGVAR(tPWMThresholdColon)
+  FSTRINGVAR(tOTPrewarnColon)
+  FSTRINGVAR(tOTTriggeredColon)
+  FSTRINGVAR(tOffTimeColon)
+  FSTRINGVAR(tBlankTimeColon)
+  FSTRINGVAR(tHystStartColon)
+  FSTRINGVAR(tHystEndColon)
+  FSTRINGVAR(tStallGuardThrColon)
+  FSTRINGVAR(tDriverStatus)
+  FSTRINGVAR(tPlusStallGuardColon)
+  FSTRINGVAR(tPlusSGResultColon)
+  FSTRINGVAR(tPlusFSActiveColon)
+  FSTRINGVAR(tPlusSTSTColon)
+  FSTRINGVAR(tPlusOLBColon)
+  FSTRINGVAR(tPlusOLAColon)
+  FSTRINGVAR(tPlusS2GBColon)
+  FSTRINGVAR(tPlusS2GAColon)
+  FSTRINGVAR(tPlusOTPWColon)
+  FSTRINGVAR(tPlusOTColon)
 #endif
 
   static void cap(FSTRINGPARAM(text));
@@ -500,6 +537,7 @@ public:
   static void config(FSTRINGPARAM(text), uint32_t value);
   static void config(FSTRINGPARAM(text), float value, uint8_t digits = 2);
   static void printNumber(uint32_t n);
+  static void printHexNumber(uint32_t n);
   static void printWarningF(FSTRINGPARAM(text));
   static void printInfoF(FSTRINGPARAM(text));
   static void printErrorF(FSTRINGPARAM(text));

--- a/src/ArduinoDUE/Repetier/Commands.cpp
+++ b/src/ArduinoDUE/Repetier/Commands.cpp
@@ -638,6 +638,297 @@ void motorCurrentReadings() {
 }
 #endif // CURRENT_CONTROL_TMC2130
 
+#if defined(DRV_TMC2130)
+// Define a struct for all available TMC2130 drivers and their (axis/extruder) names.
+static struct struct_tmc2130_drivers {
+  FSTRINGPARAM(name);
+  TMC2130Stepper **driver;
+} tmc2130_drivers[] = {
+#if TMC2130_ON_X
+  {Com::tXColon, &Printer::tmc_driver_x},
+#endif
+#if TMC2130_ON_Y
+  {Com::tYColon, &Printer::tmc_driver_y},
+#endif
+#if TMC2130_ON_Z
+  {Com::tZColon, &Printer::tmc_driver_z},
+#endif
+#if TMC2130_ON_EXT0
+  {Com::tE0Colon, &Printer::tmc_driver_e0},
+#endif
+#if TMC2130_ON_EXT1
+  {Com::tE1Colon, &Printer::tmc_driver_e1},
+#endif
+#if TMC2130_ON_EXT2
+  {Com::tE2Colon, &Printer::tmc_driver_e2},
+#endif
+  {NULL, NULL}
+};
+
+
+void tmc2130DiagnosticReadingSingleDriverLineName(uint8_t line) {
+  switch (line) {
+    case 0:
+      Com::printF(PSTR("\t"));
+      break;
+    case 1:
+      Com::printF(Com::tEnabledColon);
+      break;
+    case 2:
+      Com::printF(Com::tSetCurrentColon);
+      break;
+    case 3:
+      Com::printF(Com::tRMSCurrentColon);
+      break;
+    case 4:
+      Com::printF(Com::tMaxCurrentColon);
+      break;
+    case 5:
+      Com::printF(Com::tRunCurrentColon);
+      break;
+    case 6:
+      Com::printF(Com::tHoldCurrentColon);
+      break;
+    case 7:
+      Com::printF(Com::tCSActualColon);
+      break;
+    case 8:
+      Com::printF(Com::tPWMScaleColon);
+      break;
+    case 9:
+      Com::printF(Com::tVSENSEColon);
+      break;
+    case 10:
+      Com::printF(Com::tStealthchopColon);
+      break;
+    case 11:
+      Com::printF(Com::tMicrostepsColon);
+      break;
+    case 12:
+      Com::printF(Com::tTSTEPColon);
+      break;
+    case 13:
+      Com::printF(Com::tPWMThresholdColon);
+      break;
+    case 14:
+      Com::printF(Com::tOTPrewarnColon);
+      break;
+    case 15:
+      Com::printF(Com::tOTTriggeredColon);
+      break;
+    case 16:
+      Com::printF(Com::tOffTimeColon);
+      break;
+    case 17:
+      Com::printF(Com::tBlankTimeColon);
+      break;
+    case 18:
+      Com::printF(Com::tHystEndColon);
+      break;
+    case 19:
+      Com::printF(Com::tHystStartColon);
+      break;
+    case 20:
+      Com::printF(Com::tStallGuardThrColon);
+      break;
+    case 21:
+      Com::printF(Com::tDriverStatus);
+      break;
+    case 22:
+      Com::printF(Com::tPlusStallGuardColon);
+      break;
+    case 23:
+      Com::printF(Com::tPlusSGResultColon);
+      break;
+    case 24:
+      Com::printF(Com::tPlusFSActiveColon);
+      break;
+    case 25:
+      Com::printF(Com::tPlusSTSTColon);
+      break;
+    case 26:
+      Com::printF(Com::tPlusOLBColon);
+      break;
+    case 27:
+      Com::printF(Com::tPlusOLAColon);
+      break;
+    case 28:
+      Com::printF(Com::tPlusS2GBColon);
+      break;
+    case 29:
+      Com::printF(Com::tPlusS2GAColon);
+      break;
+    case 30:
+      Com::printF(Com::tPlusOTPWColon);
+      break;
+    case 31:
+      Com::printF(Com::tPlusOTColon);
+      break;
+  }
+}
+
+void tmc2130DiagnosticReadingSingleDriverLineValue(uint8_t line, TMC2130Stepper* tmc) {
+  switch (line) {
+    case 1:
+      if (tmc->isEnabled())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 2:
+      Com::printNumber(tmc->getCurrent());
+      break;
+    case 3:
+      Com::printNumber(tmc->rms_current());
+      break;
+    case 4:
+      Com::printFloat((float)tmc->rms_current()*1.41, 0);
+      break;
+    case 5:
+      Com::printNumber(tmc->irun()+1);
+      Com::printF(Com::tDiv32);
+      break;
+    case 6:
+      Com::printNumber(tmc->ihold()+1);
+      Com::printF(Com::tDiv32);
+      break;
+    case 7:
+      Com::printNumber(tmc->cs_actual()+1);
+      Com::printF(Com::tDiv32);
+      break;
+    case 8:
+      Com::printNumber(tmc->PWM_SCALE());
+      break;
+    case 9:
+      if  (tmc->vsense())
+        Com::printFloat(0.18f,3);
+      else
+        Com::printFloat(0.325f, 3);
+      break;
+    case 10:
+      if (tmc->stealthChop())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 11:
+      Com::printNumber(tmc->microsteps());
+      break;
+    case 12:
+      Com::printNumber(tmc->TSTEP());
+      break;
+    case 13:
+      Com::printNumber(tmc->TPWMTHRS());
+      break;
+    case 14:
+      if (tmc->otpw())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 15:
+      if (tmc->getOTPW())
+        Com::printF(Com::tTrue);
+      else
+        Com::printF(Com::tFalse);
+      break;
+    case 16:
+      Com::printNumber(tmc->toff());
+      break;
+    case 17:
+      Com::printNumber(tmc->blank_time());
+      break;
+    case 18:
+      Com::print(tmc->hysteresis_end());
+      break;
+    case 19:
+      Com::printNumber(tmc->hysteresis_start());
+      break;
+    case 20:
+      Com::printNumber(tmc->sgt());
+      break;
+    case 21:
+      // blank by purpose
+      break;
+    case 22:
+      if (tmc->stallguard())
+        Com::printF(Com::tCross);
+      break;
+    case 23:
+      Com::printNumber(tmc->sg_result());
+      break;
+    case 24:
+      if (tmc->fsactive())
+        Com::printF(Com::tCross);
+      break;
+    case 25:
+      if (tmc->stst())
+        Com::printF(Com::tCross);
+      break;
+    case 26:
+      if (tmc->olb())
+        Com::printF(Com::tCross);
+      break;
+    case 27:
+      if (tmc->ola())
+        Com::printF(Com::tCross);
+      break;
+    case 28:
+      if (tmc->s2gb())
+        Com::printF(Com::tCross);
+      break;
+    case 29:
+      if (tmc->s2ga())
+        Com::printF(Com::tCross);
+      break;
+    case 30:
+      if (tmc->otpw())
+        Com::printF(Com::tCross);
+      break;
+    case 31:
+      if (tmc->ot())
+        Com::printF(Com::tCross);
+      break;
+    default:
+      Com::printF(PSTR("?"));
+      break;
+  }
+}
+
+void tmc2130DiagnosticReadingSingleDriver(FSTRINGPARAM(text), TMC2130Stepper *tmc) {
+  Com::printF(text);
+  Com::println();
+  Com::printF(Com::tSpace);
+  Com::printHexNumber(tmc->DRV_STATUS());
+  Com::println();
+}
+
+void tmc2130DiagnosticReadings() {
+  struct struct_tmc2130_drivers *drv = tmc2130_drivers;
+  Com::printFLN(Com::tTrinamic2130DiagnosticReadings);
+  tmc2130DiagnosticReadingSingleDriverLineName(0);
+  for (uint8_t idx=0; tmc2130_drivers[idx].driver != NULL; idx++) {
+    Com::printF(PSTR("\t"));
+    Com::printF(tmc2130_drivers[idx].name);
+  }
+  Com::println();
+  for (uint8_t i=1; i<=31; i++) {
+    tmc2130DiagnosticReadingSingleDriverLineName(i);
+    for (uint8_t idx=0; tmc2130_drivers[idx].driver != NULL; idx++) {
+      Com::printF(PSTR("\t"));
+      tmc2130DiagnosticReadingSingleDriverLineValue(i, *(tmc2130_drivers[idx].driver));
+    }
+    Com::println();
+  }
+  for (uint8_t idx=0; tmc2130_drivers[idx].driver != NULL; idx++) {
+    Com::printF(tmc2130_drivers[idx].name);
+    Com::printF(PSTR("\t"));
+    Com::printHexNumber((*(tmc2130_drivers[idx].driver))->DRV_STATUS());
+    Com::println();
+  }
+}
+#endif
+
 #if STEPPER_CURRENT_CONTROL == CURRENT_CONTROL_MCP4728
 uint8_t _intVref[] = { MCP4728_VREF, MCP4728_VREF, MCP4728_VREF, MCP4728_VREF };
 uint8_t _gain[] = { MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN, MCP4728_GAIN };
@@ -2322,6 +2613,11 @@ void Commands::processMCode(GCode* com) {
     case 120: // M120 Test beeper function
         if (com->hasS() && com->hasP())
             beep(com->S, com->P); // Beep test
+        break;
+#endif
+#if defined(DRV_TMC2130)
+    case 122: // M122 TMC2130 diagnostic function
+        tmc2130DiagnosticReadings();
         break;
 #endif
 #if MIXING_EXTRUDER > 0

--- a/src/ArduinoDUE/Repetier/Communication.cpp
+++ b/src/ArduinoDUE/Repetier/Communication.cpp
@@ -140,6 +140,7 @@ FSTRINGVALUE(Com::tYColon, "Y:")
 FSTRINGVALUE(Com::tZColon, "Z:")
 FSTRINGVALUE(Com::tE0Colon, "E0:")
 FSTRINGVALUE(Com::tE1Colon, "E1:")
+FSTRINGVALUE(Com::tE2Colon, "E2:")
 FSTRINGVALUE(Com::tMS1MS2Pins, "MS1,MS2 Pins")
 FSTRINGVALUE(Com::tSetOutputSpace, "Set output: ")
 FSTRINGVALUE(Com::tGetInputSpace, "Get Input: ")
@@ -500,6 +501,42 @@ FSTRINGVALUE(Com::tStartupGCode, STARTUP_GCODE)
 #ifdef DRV_TMC2130
 FSTRINGVALUE(Com::tTrinamicMotorCurrent, "Trinamic motor current:")
 FSTRINGVALUE(Com::tTrinamicMicrostepMode, "Trinamic microstep mode:")
+FSTRINGVALUE(Com::tTrinamic2130DiagnosticReadings, "Trinamic 2130 diagnostic readings:")
+FSTRINGVALUE(Com::tTrue, "True");
+FSTRINGVALUE(Com::tFalse, "False");
+FSTRINGVALUE(Com::tDiv32, "/32");
+FSTRINGVALUE(Com::tCross, "X");
+FSTRINGVALUE(Com::tEnabledColon,        "Enabled:")
+FSTRINGVALUE(Com::tSetCurrentColon,     "Set current:")
+FSTRINGVALUE(Com::tRMSCurrentColon,     "RMS current:")
+FSTRINGVALUE(Com::tMaxCurrentColon,     "Max current:")
+FSTRINGVALUE(Com::tRunCurrentColon,     "Run current:")
+FSTRINGVALUE(Com::tHoldCurrentColon,    "Hold current:")
+FSTRINGVALUE(Com::tCSActualColon,       "CS actual:")
+FSTRINGVALUE(Com::tPWMScaleColon,       "PWM scale:")
+FSTRINGVALUE(Com::tVSENSEColon,         "VSENSE:\t")
+FSTRINGVALUE(Com::tStealthchopColon,    "Stealthchop:")
+FSTRINGVALUE(Com::tMicrostepsColon,     "Microsteps:")
+FSTRINGVALUE(Com::tTSTEPColon,          "TSTEP:\t")
+FSTRINGVALUE(Com::tPWMThresholdColon,   "PWM threshold:")
+FSTRINGVALUE(Com::tOTPrewarnColon,      "OT prewarn:")
+FSTRINGVALUE(Com::tOTTriggeredColon,    "OT triggered:")
+FSTRINGVALUE(Com::tOffTimeColon,        "Off time:")
+FSTRINGVALUE(Com::tBlankTimeColon,      "Blank time:")
+FSTRINGVALUE(Com::tHystEndColon,        "Hyst. end:")
+FSTRINGVALUE(Com::tHystStartColon,      "Hyst. start:")
+FSTRINGVALUE(Com::tStallGuardThrColon,  "StallGuard thr:")
+FSTRINGVALUE(Com::tDriverStatus,   "Driver Status")
+FSTRINGVALUE(Com::tPlusStallGuardColon, "+ StallGuard:")
+FSTRINGVALUE(Com::tPlusSGResultColon,   "+ sg_result:")
+FSTRINGVALUE(Com::tPlusFSActiveColon,   "+ fsactive:")
+FSTRINGVALUE(Com::tPlusSTSTColon,       "+ stst:\t")
+FSTRINGVALUE(Com::tPlusOLBColon,        "+ olb:\t")
+FSTRINGVALUE(Com::tPlusOLAColon,        "+ ola:\t")
+FSTRINGVALUE(Com::tPlusS2GBColon,       "+ s2gb:\t")
+FSTRINGVALUE(Com::tPlusS2GAColon,       "+ s2ga:\t")
+FSTRINGVALUE(Com::tPlusOTPWColon,       "+ otpw:\t")
+FSTRINGVALUE(Com::tPlusOTColon,         "+ ot:\t")
 #endif
 bool Com::writeToAll = true; // transmit start messages to all devices!
 
@@ -671,6 +708,26 @@ void Com::printNumber(uint32_t n)
 
   print(str);
 }
+
+void Com::printHexNumber(uint32_t n)
+{
+  char buf[11]; // Assumes 8-bit chars plus zero byte.
+  char *str = &buf[10];
+  buf[0] = '0';
+  buf[1] = 'x';
+  buf[10] = '\0';
+  do
+  {
+    uint8_t nibble = n&0x0F;
+    if (nibble > 9)
+      *--str = 'A'+(nibble-0xA);
+    else
+      *--str = '0'+nibble;
+    n>>=4;
+  } while (str != &buf[2]);
+  print(buf);
+}
+
 void Com::printArrayFLN(FSTRINGPARAM(text), float *arr, uint8_t n,
                         uint8_t digits)
 {

--- a/src/ArduinoDUE/Repetier/Communication.h
+++ b/src/ArduinoDUE/Repetier/Communication.h
@@ -176,6 +176,7 @@ public:
   FSTRINGVAR(tZColon)
   FSTRINGVAR(tE0Colon)
   FSTRINGVAR(tE1Colon)
+  FSTRINGVAR(tE2Colon)
   FSTRINGVAR(tMS1MS2Pins)
   FSTRINGVAR(tSetOutputSpace)
   FSTRINGVAR(tGetInputSpace)
@@ -490,6 +491,42 @@ public:
 #ifdef DRV_TMC2130
   FSTRINGVAR(tTrinamicMotorCurrent)
   FSTRINGVAR(tTrinamicMicrostepMode)
+  FSTRINGVAR(tTrinamic2130DiagnosticReadings)
+  FSTRINGVAR(tTrue)
+  FSTRINGVAR(tFalse)
+  FSTRINGVAR(tDiv32)
+  FSTRINGVAR(tCross)
+  FSTRINGVAR(tEnabledColon)
+  FSTRINGVAR(tSetCurrentColon)
+  FSTRINGVAR(tRMSCurrentColon)
+  FSTRINGVAR(tMaxCurrentColon)
+  FSTRINGVAR(tRunCurrentColon)
+  FSTRINGVAR(tHoldCurrentColon)
+  FSTRINGVAR(tCSActualColon)
+  FSTRINGVAR(tPWMScaleColon)
+  FSTRINGVAR(tVSENSEColon)
+  FSTRINGVAR(tStealthchopColon)
+  FSTRINGVAR(tMicrostepsColon)
+  FSTRINGVAR(tTSTEPColon)
+  FSTRINGVAR(tPWMThresholdColon)
+  FSTRINGVAR(tOTPrewarnColon)
+  FSTRINGVAR(tOTTriggeredColon)
+  FSTRINGVAR(tOffTimeColon)
+  FSTRINGVAR(tBlankTimeColon)
+  FSTRINGVAR(tHystStartColon)
+  FSTRINGVAR(tHystEndColon)
+  FSTRINGVAR(tStallGuardThrColon)
+  FSTRINGVAR(tDriverStatus)
+  FSTRINGVAR(tPlusStallGuardColon)
+  FSTRINGVAR(tPlusSGResultColon)
+  FSTRINGVAR(tPlusFSActiveColon)
+  FSTRINGVAR(tPlusSTSTColon)
+  FSTRINGVAR(tPlusOLBColon)
+  FSTRINGVAR(tPlusOLAColon)
+  FSTRINGVAR(tPlusS2GBColon)
+  FSTRINGVAR(tPlusS2GAColon)
+  FSTRINGVAR(tPlusOTPWColon)
+  FSTRINGVAR(tPlusOTColon)
 #endif
 
   static void cap(FSTRINGPARAM(text));
@@ -500,6 +537,7 @@ public:
   static void config(FSTRINGPARAM(text), uint32_t value);
   static void config(FSTRINGPARAM(text), float value, uint8_t digits = 2);
   static void printNumber(uint32_t n);
+  static void printHexNumber(uint32_t n);
   static void printWarningF(FSTRINGPARAM(text));
   static void printInfoF(FSTRINGPARAM(text));
   static void printErrorF(FSTRINGPARAM(text));


### PR DESCRIPTION
Like it is in Marlin firmware, I added a **M122** command to output TMC2130 diagnostic readings to read out many settings and additional runtime diagnostic output like if the motor is in stall or was shutdown due to over-temperature.

Example output from running M122 to the board:
```
Trinamic 2130 diagnostic readings:
		X:	Y:	Z:	E0:	E1:
Enabled:	False	False	False	False	False
Set current:	500	500	500	500	500
RMS current:	489	489	489	489	489
Max current:	689	689	689	689	689
Run current:	16/32	16/32	16/32	16/32	16/32
Hold current:	8/32	8/32	8/32	8/32	8/32
CS actual:	8/32	8/32	8/32	8/32	8/32
PWM scale:	0	0	0	0	0
VSENSE:		0.180	0.180	0.180	0.180	0.180
Stealthchop:	True	True	True	True	True
Microsteps:	16	16	16	16	16
TSTEP:		1048575	1048575	1048575	1048575	1048575
PWM threshold:	0	0	0	0	0
OT prewarn:	False	False	False	False	False
OT triggered:	False	False	False	False	False
Off time:	8	8	8	8	8
Blank time:	24	24	24	24	24
Hyst. end:	-3	-3	-3	-3	-3
Hyst. start:	1	1	1	1	1
StallGuard thr:	0	0	0	0	0
Driver Status					
+ StallGuard:					
+ sg_result:	0	0	0	0	0
+ fsactive:					
+ stst:		X	X	X	X	X
+ olb:						
+ ola:						
+ s2gb:						
+ s2ga:						
+ otpw:						
+ ot:						
X:	0x80070000
Y:	0x80070000
Z:	0x80070000
E0:	0x80070000
E1:	0x80070000
```

The output format is similar to the Marlin one.