### PR TITLE
Move Init of HAL SPI before IO_TARGET 1 for using it in SPI related m…

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -472,6 +472,11 @@ void Printer::setup() {
     PULLUP(SDCARDDETECT, HIGH);
 #endif
 #endif
+
+#ifndef NO_SPI
+    HAL::spiInit();
+#endif
+
     // Define io functions
 #undef IO_TARGET
 #define IO_TARGET 1

--- a/src/Repetier/src/boards/SAMD51/HAL.cpp
+++ b/src/Repetier/src/boards/SAMD51/HAL.cpp
@@ -202,9 +202,6 @@ void HAL::setupTimer() {
     SYNC_TIMER(SERVO_TIMER);
 
 #endif
-#ifndef NO_SPI
-    HAL::spiInit();
-#endif
 }
 
 struct PWMChannel {

--- a/src/Repetier/src/boards/due/HAL.cpp
+++ b/src/Repetier/src/boards/due/HAL.cpp
@@ -145,9 +145,6 @@ void HAL::setupTimer() {
     SERVO_TIMER->TC_CHANNEL[SERVO_TIMER_CHANNEL].TC_IDR = ~TC_IER_CPCS;
     NVIC_EnableIRQ((IRQn_Type)SERVO_TIMER_IRQ);
 #endif
-#ifndef NO_SPI
-    HAL::spiInit();
-#endif
 }
 
 struct PWMPin {

--- a/src/Repetier/src/io/io_spi.h
+++ b/src/Repetier/src/io/io_spi.h
@@ -19,7 +19,14 @@
 #undef IO_SPI_HW
 #undef IO_SPI_SW
 
-#if IO_TARGET == 4 // class
+#if IO_TARGET == 1 // 
+
+#define IO_SPI_HW(name, frequency, mode, msbfirst, csPin) \
+    name.init();
+#define IO_SPI_SW(name, delayus, mode, msbfirst, csPin, clkPin, misoPin, mosiPin) \
+    name.init();
+
+#elif IO_TARGET == 4 // class
 
 /**
  * Classes using SPI will get a super easy interface. To start a transfer they
@@ -81,9 +88,12 @@ public:
     class name##Class : public RFSpiBase { \
     public: \
         name##Class() { \
+        } \
+        virtual void init()\
+        {\
             SET_OUTPUT(csPin); \
             WRITE(csPin, 1); \
-        } \
+        }\
         virtual void begin() { \
             HAL::spiBegin(frequency, mode, msbfirst); \
             WRITE(csPin, 0); \
@@ -106,6 +116,9 @@ public:
 \
     public: \
         name##Class() { \
+        } \
+        virtual void init()\
+        {\
             SET_OUTPUT(csPin); \
             WRITE(csPin, 1); \
             SET_OUTPUT(clkPin); \
@@ -115,7 +128,7 @@ public:
             if (mosiPin >= 0) { \
                 HAL::pinMode(mosiPin, OUTPUT); \
             } \
-        } \
+        }\
         virtual void begin() { \
             WRITE(clkPin, modeCPOL()); \
             if (!modeCPHA()) { \


### PR DESCRIPTION
…odules.

IO_SPI_HW - Move Pin definition from constructor to init and call them at IO_TARGET 1.