### PR TITLE
- Fix wrong position after homing Z with z Probe and zoffset for xy

### DIFF
--- a/src/Repetier/src/communication/GCodes.cpp
+++ b/src/Repetier/src/communication/GCodes.cpp
@@ -237,6 +237,7 @@ void GCode_30(GCode* com) {
         Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[Z_AXIS], false);
         float zheight = ZProbeHandler::runProbe();
         if (zheight == ILLEGAL_Z_PROBE) {
+             GCode::fatalError(PSTR("G30 probing failed!"));
             return;
         }
         float zProbeHeight = ZProbeHandler::getZProbeHeight() + startHeight - zheight;

--- a/src/Repetier/src/motion/MotionLevel1.cpp
+++ b/src/Repetier/src/motion/MotionLevel1.cpp
@@ -528,7 +528,7 @@ bool Motion1::moveByOfficial(float coords[NUM_AXES], float feedrate, bool second
 }
 
 void Motion1::setToolOffset(float ox, float oy, float oz) {
-    if (Motion1::isAxisHomed(X_AXIS) && Motion1::isAxisHomed(Y_AXIS) && Motion1::isAxisHomed(Z_AXIS)) {
+    if (Motion1::isAxisHomed(X_AXIS) && Motion1::isAxisHomed(Y_AXIS)) {
         setTmpPositionXYZ(currentPosition[X_AXIS] + ox - toolOffset[X_AXIS],
                           currentPosition[Y_AXIS] + oy - toolOffset[Y_AXIS],
                           currentPosition[Z_AXIS]);
@@ -1275,7 +1275,7 @@ void Motion1::homeAxes(fast8_t axes) {
     }
 #endif
 #if FIXED_Z_HOME_POSITION
-    if (axes && axisBits[Z_AXIS]) { // ensure x and y are homed
+    if (axes & axisBits[Z_AXIS]) { // ensure x and y are homed
         if (!isAxisHomed(X_AXIS)) {
             axes |= axisBits[X_AXIS];
         }


### PR DESCRIPTION
After first G28 position (real vs. corrdinates) was wrong. Second time worked because then all axes were alligned. 
Unsure this is the right fix for all ZProbe type cases but it fixes the bug for zprobe 1 with offsets.
Fix is in setToolOffset