### PR TITLE
Support for TMC2209 drivers.

### DIFF
--- a/src/Repetier/src/drivers/stepper.cpp
+++ b/src/Repetier/src/drivers/stepper.cpp
@@ -96,7 +96,7 @@ void AdjustResolutionStepperDriver<driver>::eepromHandle() {
 
 #define PSB_STALL_SENSITIVITY_POS PSB_STEALTH_POS + PSB_STEALTH_SIZE
 #if STORE_MOTOR_STALL_SENSITIVITY
-#define PSB_STALL_SENSITIVITY_SIZE 1
+#define PSB_STALL_SENSITIVITY_SIZE 2
 #else
 #define PSB_STALL_SENSITIVITY_SIZE 0
 #endif
@@ -129,8 +129,10 @@ void ProgrammableStepperBase::processEEPROM(uint8_t flags) {
     }
 #endif
 #if STORE_MOTOR_STALL_SENSITIVITY
+    //Note, flag 32 is stallguard 4, we don't use that flag for anything else yet, other than a small change in eeprom text.
     if (flags & 16 && stallguardSensitivity != -128) {
-        EEPROM::handleByte(eprStart + PSB_STALL_SENSITIVITY_POS, PSTR("Stall Sensitivity [-64..63]"), stallguardSensitivity);
+        EEPROM::handleInt(eprStart + PSB_STALL_SENSITIVITY_POS, (flags & 32) ? 
+                PSTR("Stall Sensitivity [0..255]") : PSTR("Stall Sensitivity [-64..63]"), stallguardSensitivity);
     }
 #endif
 }
@@ -879,6 +881,278 @@ void TMCStepper2208Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& 
     case 914: // sensorless homing sensitivity
         printMotorNumberAndName(false);
         Com::printFLN(PSTR(" stallguard sensitivity not supported by TMC2208 "));
+        break;
+    }
+}
+
+// ---- TMC2209 -------------
+void reportTMC2209(TMC2209Stepper* driver, ProgrammableStepperBase* b, int level) {
+    uint8_t constat = driver->test_connection();
+    Com::printF(PSTR("Status: "));
+    switch (constat) {
+    case 0:
+        Com::printFLN(PSTR("Ok"));
+        break;
+    case 1:
+        Com::printFLN(PSTR("No connection"));
+        break;
+    case 2:
+        Com::printFLN(PSTR("No power"));
+        break;
+    }
+    Com::printFLN(PSTR("Enabled: "), driver->isEnabled(), BoolFormat::YESNO);
+    Com::printF(PSTR("Current [mA]: "), driver->rms_current());
+    Com::printFLN(PSTR(" set: "), b->getCurrentMillis());
+    Com::printFLN(PSTR("Max. current [mA]: "), 1.4142 * driver->rms_current(), 0);
+    Com::printF(PSTR("Microsteps: "), driver->microsteps());
+    Com::printFLN(PSTR(" mres:"), (int)driver->mres());
+    Com::printFLN(PSTR("StealthChop: "), b->getStealthChop(), BoolFormat::ONOFF);
+    if (b->getHybridSpeed() > 0) {
+        Com::printFLN(PSTR("Hybrid treshold [mm/s]: "), b->getHybridSpeed(), 2);
+    } else {
+        Com::printFLN(PSTR("Hybrid mode disabled"));
+    }
+    Com::printFLN(PSTR("StallGuard Result: "), driver->SG_RESULT());
+
+    if (level > 0) {
+        const uint32_t tstep = driver->TSTEP();
+        Com::printF(PSTR("TSTEP: "));
+        if (tstep != 0xFFFFF) {
+            Com::print(static_cast<int32_t>(tstep));
+            Com::println();
+        } else {
+            Com::printFLN("max");
+        }
+        Com::printFLN(PSTR("TPWMTHRS: "), driver->TPWMTHRS());
+        Com::printFLN(PSTR("TPOWERDOWN: "), (int)driver->TPOWERDOWN());
+        Com::printF(PSTR("IRUN: "), driver->irun());
+        Com::printFLN(PSTR("/31"));
+        Com::printF(PSTR("IHOLD: "), driver->ihold());
+        Com::printFLN(PSTR("/31"));
+        Com::printF(PSTR("CS Actual: "), driver->cs_actual());
+        Com::printFLN(PSTR("/31"));
+        // Com::printFLN(PSTR("vsense: "), driver->vsense());
+        Com::printFLN(PSTR("toff: "), (int)driver->toff());
+        Com::printFLN(PSTR("hstart: "), (int)driver->hysteresis_start());
+        Com::printFLN(PSTR("hend: "), (int)driver->hysteresis_end());
+        Com::printF(PSTR("Blank time: "), (int)driver->blank_time());
+        Com::printFLN(PSTR(" tbl: "), (int)driver->tbl());
+        Com::printFLN(PSTR("IOIN: "), driver->IOIN());
+        Com::printFLN(PSTR("GSTAT: "), (int)driver->GSTAT());
+
+        Com::printFLN(PSTR("COOLCONF: "), (int)driver->COOLCONF());
+        Com::printFLN(PSTR("semin: "), (int)driver->semin());
+        Com::printFLN(PSTR("seup: "), (int)driver->seup());
+        Com::printFLN(PSTR("semax: "), (int)driver->semax());
+        Com::printFLN(PSTR("sedn: "), (int)driver->sedn());
+        Com::printFLN(PSTR("seimin: "), (int)driver->seimin()); 
+        
+    }
+}
+
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::init() {
+    disable();
+    driver->begin();
+
+    // The TMC2209_n namespace doesn't recreate all the register structs for the 2209 specifically
+    // We're meant to use the 2208's. 
+    // However, it does have it's own IOIN_t, COOLCONF_t, SG_RESULT_t, and SGTHRS_t tables!
+    
+    TMC2208_n::GCONF_t gconf { 0 };
+    gconf.pdn_disable = true;      // Use UART
+    gconf.mstep_reg_select = true; // Select microsteps with UART
+    gconf.i_scale_analog = false;
+    gconf.en_spreadcycle = !stealthChop;
+    driver->GCONF(gconf.sr);
+
+    TMC2208_n::CHOPCONF_t chopconf { 0 };
+    chopconf.tbl = 1;
+    chopconf.toff = tmcChopperTiming.toff;
+    chopconf.intpol = TMC_INTERPOLATE;
+    chopconf.hend = tmcChopperTiming.hend + 3;   // -3 .. 12
+    chopconf.hstrt = tmcChopperTiming.hstrt - 1; // 1 .. 16 but hend+hstart <= 16
+                                                 // #if ENABLED(TMC_SQUARE_WAVE_STEPPING)
+                                                 //    chopconf.dedge = true;
+                                                 // #endif
+    driver->CHOPCONF(chopconf.sr);
+
+    driver->rms_current(currentMillis, TMC_HOLD_MULTIPLIER);
+    driver->microsteps(microsteps);
+    driver->iholddelay(10);
+    driver->TPOWERDOWN(128); // ~2s until driver lowers to hold current
+
+    
+    
+    TMC2208_n::PWMCONF_t pwmconf { 0 };
+    pwmconf.pwm_lim = 12;
+    pwmconf.pwm_reg = 8;
+    pwmconf.pwm_autograd = true;
+    pwmconf.pwm_autoscale = true;
+    pwmconf.pwm_freq = 0b01;
+    pwmconf.pwm_grad = 14;
+    pwmconf.pwm_ofs = 36;
+    driver->PWMCONF(pwmconf.sr); 
+
+    
+    //TMC2209_n::COOLCONF_t coolconf { 0 };  
+
+    if (hybridSpeed >= 0) {
+        driver->TPWMTHRS(fclk * microsteps / static_cast<uint32_t>(256 * hybridSpeed * Motion1::resolution[getAxis()])); // need computed
+    } else {
+        driver->TPWMTHRS(0); // Only stealthChop or spreadCycle
+    }
+
+    if (stallguardSensitivity != -128) {
+        stallguardSensitivity = constrain(stallguardSensitivity, 0, 255);
+        driver->SGTHRS(stallguardSensitivity);
+    }
+    driver->GSTAT(); // Clear GSTAT
+}
+
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::eepromHandle() {
+    PGM_P* adr = (PGM_P*)pgm_read_word(&motorNames);
+    EEPROM::handlePrefix(adr[motorIndex()]);
+    processEEPROM(63); //StallGuard 4, flag 32
+    EEPROM::removePrefix();
+}
+
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::eepromReserve() {
+    reserveEEPROM(0);
+}
+
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::reset(uint16_t _microsteps, uint16_t _currentMillis, bool _stealthChop, float _hybridThrs, int16_t _stallSensitivity) {
+    microsteps = _microsteps;
+    currentMillis = _currentMillis;
+    stealthChop = _stealthChop;
+    hybridSpeed = _hybridThrs;
+    stallguardSensitivity = _stallSensitivity;
+    init();
+}
+
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::timer500ms() {
+    if (debug != -1) {
+        reportTMC2209(driver, this, debug);
+    }
+    // Access of bits results in reading register again, so we buffer result
+    TMC2208_n::DRV_STATUS_t status { driver->DRV_STATUS() };
+    if (status.sr == 0xFFFFFFFF || status.sr == 0x0) { // not in working state
+        return;
+    }
+    if (status.ot) { // over temperature
+        printMotorNumberAndName(false);
+        Com::printFLN(" driver overtemperature! Current: ", currentMillis);
+    }
+    if (status.otpw) { // over temperature prewarn
+        if (otpwCount < 255) {
+            otpwCount++;
+        }
+        if (otpwCount == 1) {
+            printMotorNumberAndName(false);
+            Com::printFLN(" driver overtemperature warning! Current: ", currentMillis);
+        }
+#if TMC_CURRENT_STEP_DOWN > 0
+        if (otpwCount > 4 && driver->isEnabled()) {
+            if (currentMillis > 100) {
+                currentMillis -= TMC_CURRENT_STEP_DOWN;
+                driver->rms_current(currentMillis);
+                printMotorNumberAndName(false);
+                Com::printFLN(" current decreased to ", currentMillis);
+            }
+        }
+#endif
+        otpw = true;
+    } else {
+        otpwCount = 0;
+    }
+}
+
+/// Set microsteps. Must be a power of 2.
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::setMicrosteps(int _microsteps) {
+    microsteps = _microsteps;
+    driver->microsteps(microsteps);
+    reportTMC2209(driver, this, 0);
+}
+
+/// Set max current as range 0..255 or mA depedning on driver
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::setMaxCurrent(int max) {
+    currentMillis = max;
+    driver->rms_current(max);
+    reportTMC2209(driver, this, 0);
+}
+
+// Called before homing starts. Can be used e.g. to disable silent mode
+// or otherwise prepare for endstop detection.
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::beforeHoming() {
+}
+
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::afterHoming() {
+}
+
+template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
+void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& com) {
+    switch (com.M) {
+    case 122: // print debug informations
+    {
+        Com::println();
+        printMotorNumberAndName();
+        reportTMC2209(driver, this, com.hasD() ? static_cast<int>(com.D) : 0);
+        if (com.hasS()) {
+            if (com.S) {
+                debug = RMath::max(static_cast<int16_t>(0), RMath::min(static_cast<int16_t>(2), com.hasD() ? static_cast<int16_t>(com.D) : static_cast<int16_t>(0)));
+            } else {
+                debug = -1;
+            }
+        }
+    } break;
+    case 569: // Set steathchop with S
+        if (com.hasS()) {
+            stealthChop = com.S != 0;
+            TMC2208_n::GCONF_t gconf { 0 };
+            gconf.pdn_disable = true;      // Use UART
+            gconf.mstep_reg_select = true; // Select microsteps with UART
+            gconf.i_scale_analog = false;
+            gconf.en_spreadcycle = !stealthChop;
+            driver->GCONF(gconf.sr);
+        }
+        printMotorNumberAndName(false);
+        Com::printFLN(PSTR(" stealthChop:"), stealthChop, BoolFormat::ONOFF);
+        break;
+    case 911: // Report TMC prewarn
+        printMotorNumberAndName(false);
+        Com::printFLN(PSTR(" temperature prewarn triggered: "), otpw, BoolFormat::TRUEFALSE);
+        break;
+    case 912: // Clear prewarn
+        otpw = false;
+        otpwCount = 0;
+        printMotorNumberAndName(false);
+        Com::printFLN(PSTR(" prewarn flag cleared"));
+        break;
+    case 913: // Hybrid treshold
+        if (com.hasX()) {
+            hybridSpeed = com.X;
+            init();
+        }
+        printMotorNumberAndName(false);
+        Com::printFLN(PSTR(" hybrid treshold: "), hybridSpeed, 1);
+        break;
+        
+    case 914: // sensorless homing sensitivity
+        if (hasStallguard()) {
+            if (com.hasS() && com.S >= 0 && com.S <= 255) {
+                stallguardSensitivity = static_cast<int16_t>(com.S);
+            }
+            printMotorNumberAndName(false);
+            Com::printFLN(PSTR(" stallguard sensitivity: "), stallguardSensitivity);
+        }
         break;
     }
 }

--- a/src/Repetier/src/io/io_stepper.h
+++ b/src/Repetier/src/io/io_stepper.h
@@ -27,6 +27,7 @@
 #undef STEPPER_TMC2130_SW_SPI
 #undef STEPPER_TMC5160_SW_SPI
 #undef STEPPER_TMC2208_HW_UART
+#undef STEPPER_TMC2209_HW_UART
 
 #if IO_TARGET == IO_TARGET_CLASS_DEFINITION // declare variable
 
@@ -53,6 +54,10 @@
     extern TMC2208Stepper name##Inst; \
     extern TMCStepper2208Driver<stepPin, dirPin, enablePin, fclk> name; \
     typedef TMCStepper2208Driver<stepPin, dirPin, enablePin, fclk> name##Type;
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
+    extern TMC2209Stepper name##Inst; \
+    extern TMCStepper2209Driver<stepPin, dirPin, enablePin, fclk> name; \
+    typedef TMCStepper2209Driver<stepPin, dirPin, enablePin, fclk> name##Type;
 #define STEPPER_MIRROR2(name, motor1, motor2, minEndstop, maxEndstop) \
     extern Mirror2StepperDriver name; \
     typedef Mirror2StepperDriver name##Type;
@@ -88,6 +93,9 @@
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
     TMC2208Stepper name##Inst(&serial, rsense, (bool)true); \
     TMCStepper2208Driver<stepPin, dirPin, enablePin, fclk> name(&minEndstop, &maxEndstop, &name##Inst, microsteps, currentMillis, stealth, hybridSpeed);
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
+    TMC2209Stepper name##Inst(&serial, rsense, slaveAddr); \
+    TMCStepper2209Driver<stepPin, dirPin, enablePin, fclk> name(&minEndstop, &maxEndstop, &name##Inst, microsteps, currentMillis, stealth, hybridSpeed, stallSensitivity);
 #define STEPPER_MIRROR2(name, motor1, motor2, minEndstop, maxEndstop) \
     Mirror2StepperDriver name(&motor1, &motor2, &minEndstop, &maxEndstop);
 #define STEPPER_MIRROR3(name, motor1, motor2, motor3, minEndstop, maxEndstop) \
@@ -112,6 +120,9 @@
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
     serial.begin(115200); \
     name.eepromReserve();
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
+    serial.begin(500000); \
+    name.eepromReserve();
 
 #elif IO_TARGET == IO_TARGET_INIT_LATE // Init drivers at startup
 
@@ -126,6 +137,8 @@
 #define STEPPER_TMC5160_SW_SPI(name, stepPin, dirPin, enablePin, mosiPin, misoPin, sckPin, csPin, rsense, chainPos, microsteps, currentMillis, stealth, hybridSpeed, stallSensitivity, fclk, minEndstop, maxEndstop) \
     name.init();
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
+    name.init();
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
     name.init();
 #define STEPPER_MIRROR2(name, motor1, motor2, minEndstop, maxEndstop) \
     name.init();
@@ -151,6 +164,8 @@
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
     name.reset(microsteps, currentMillis, stealth, hybridSpeed);
 
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
+    name.reset(microsteps, currentMillis, stealth, hybridSpeed, stallSensitivity);
 #elif IO_TARGET == IO_TARGET_TOOLS_TEMPLATES
 
 #define STEPPER_ADJUST_RESOLUTION(name, driver, from, to) \
@@ -165,6 +180,8 @@
     template class TMCStepper5160Driver<stepPin, dirPin, enablePin, fclk>;
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
     template class TMCStepper2208Driver<stepPin, dirPin, enablePin, fclk>;
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
+    template class TMCStepper2209Driver<stepPin, dirPin, enablePin, fclk>;   
 
 #elif IO_TARGET == IO_TARGET_UPDATE_DERIVED // call updatedDerived to activate new settings
 
@@ -178,6 +195,8 @@
     name.init();
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
     name.init();
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
+    name.init();
 
 #elif IO_TARGET == IO_TARGET_500MS
 
@@ -190,6 +209,8 @@
 #define STEPPER_TMC5160_SW_SPI(name, stepPin, dirPin, enablePin, mosiPin, misoPin, sckPin, csPin, rsense, chainPos, microsteps, currentMillis, stealth, hybridSpeed, stallSensitivity, fclk, minEndstop, maxEndstop) \
     name.timer500ms();
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
+    name.timer500ms();
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
     name.timer500ms();
 
 #endif
@@ -211,6 +232,9 @@
 #endif
 #ifndef STEPPER_TMC2208_HW_UART
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop)
+#endif
+#ifndef STEPPER_TMC2209_HW_UART
+#define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) 
 #endif
 #ifndef STEPPER_MIRROR2
 #define STEPPER_MIRROR2(name, motor1, motor2, minEndstop, maxEndstop)


### PR DESCRIPTION
I'm running the newest TMC2209 drivers that were recently released on my machine. I added some support for them with repetier V2 on a small forked repo of mine a little while ago. It's just a copy of the current TMC2208 classes/setup with some minor changes (individual UART addresses, stallgaurd4 etc).

- Stallguard4 uses values between 0-255. The stall sensitivity EEPROM/respective values were replaced with short instead of byte to support the new range (and the old range).

- I quickly added on a new flag (32) on line 132 for stepper.cpp just to display the correct value range to the user if they're using stallguard4 vs stallguard2. Could possibly be handled differently.

- I'm running these with the baudrate set to 500000, though they should support up to 700000 baud (stock fclk)

- Haven't added any coolStep configuration options for them. I don't believe the options are considerably important for now, and I noticed some other driver definitions currently lack them as well. 

I was originally planning to add in some pin interrupt handling for the diag output on these at some point, but I realized repetier wrote some support for this already. (ENDSTOP_STEPPER ?) 

([b774dea](https://github.com/AbsoluteCatalyst/Repetier-Firmware-V2/commit/b774dea387bfa8a53ba3013063f2d52fb5265e14) original commit w/some info.)