### PR TITLE
Allow ARM-based (due) boards to attach endstop hw switches to any pins.

### DIFF
--- a/src/Repetier/src/io/io_endstop_definitions.h
+++ b/src/Repetier/src/io/io_endstop_definitions.h
@@ -42,8 +42,9 @@
 
 #define ENDSTOP_NONE(name)
 #define ENDSTOP_SWITCH(name, pin)
+
 #define ENDSTOP_SWITCH_HW(name, _pin, axis, dir) \
-    attachInterrupt(digitalPinToInterrupt(_pin::pin()), name##_cb, CHANGE); \
+    attachInterrupt((CPU_ARCH != ARCH_AVR) ? _pin::pin() : digitalPinToInterrupt(_pin::pin()), name##_cb, CHANGE); \
     name.updateReal();
 
 #define ENDSTOP_SWITCH_DEBOUNCE(name, pin, level)


### PR DESCRIPTION
Small fix to bypass digitalPinToInterrupt checks for arm boards which may have pins defined beyond the 66 that function limits to. 