### PR TITLE
Output EEPROM at any point using emergency parser.

### DIFF
--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -566,8 +566,10 @@ void Commands::processMCode(GCode* com) {
     case 204: // M204
         MCode_204(com);
         break;
-    case 205: // M205 Show EEPROM settings
+    case 205: // M205 Show EEPROM settings 
+    #if EMERGENCY_PARSER == 0
         MCode_205(com);
+    #endif
         break;
     case 206: // M206 T[type] P[pos] [Sint(long] [Xfloat]  Set eeprom value
         MCode_206(com);

--- a/src/Repetier/src/communication/gcode.cpp
+++ b/src/Repetier/src/communication/gcode.cpp
@@ -1267,7 +1267,9 @@ void SerialGCodeSource::testEmergency(GCode& gcode) {
             PrinterType::M290(&gcode);
         } else if (gcode.M == 416) {
             Printer::handlePowerLoss();
-        }
+        } else if (gcode.M == 205) { 
+            EEPROM::writeSettings(); 
+        } 
     }
 }
 


### PR DESCRIPTION
Added M205 to the emergency parser as well to let repetier-server's interface read the eeprom even during long wait commands. 

In the original commit I mentioned that it only works around 7 times during waits. 
I believe I fixed this by adding M205 to the <PriorityCommands> tree on repetier-server's firmware xml file.