### PR TITLE
Add M106 D<delay> parameter for fans.

### DIFF
--- a/src/Repetier/src/Events.h
+++ b/src/Repetier/src/Events.h
@@ -158,4 +158,8 @@ Each of the following events describe the parameter and when it is called.
 #define EVENT_CUSTOM_TOOL_CHANGE_SETUP(tool) \
     {}
 
+// Called when a fan reaches it's M106 D<seconds> timeout
+#define EVENT_FAN_TIMEOUT(fanId, targetSpeed) \
+    {}
+ 
 #endif // EVENTS_H_INCLUDED

--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -179,15 +179,15 @@ void Printer::setFanSpeed(int speed, bool immediately, int fanId, int timeout) {
     speed = TRIM_FAN_PWM(constrain(speed, 0, 255));
     Tool* tool = nullptr;
     Tool* activeTool = Tool::getActiveTool();
-    if(timeout) {
+    if (timeout) {
         fans[fanId].target = speed;
         fans[fanId].time = HAL::timeInMilliseconds();
         fans[fanId].timeout = (timeout * 1000);
         return;
     }
 
-    if(fans[fanId].timeout) {
-        fans[fanId] = (fanController) {fans[fanId].fan, 0, 0, 0};
+    if (fans[fanId].timeout) {
+        fans[fanId] = (fanController){ fans[fanId].fan, 0, 0, 0 };
     }
     Com::printF(PSTR("Fanspeed"), fanId);
     Com::printFLN(Com::tColon, speed);
@@ -209,14 +209,15 @@ void Printer::setFanSpeed(int speed, bool immediately, int fanId, int timeout) {
             }
         }
     }
-    fans[fanId].fan->set(speed); 
+    fans[fanId].fan->set(speed);
 }
 
 void Printer::checkFanTimeouts() {
-    for (int i = 0; i < NUM_FANS; i++) {
-        if(fans[i].timeout) {
-            if((HAL::timeInMilliseconds() - fans[i].time) > fans[i].timeout) { 
-                Printer::setFanSpeed(fans[i].target, 1, i); 
+    for (fast8_t i = 0; i < NUM_FANS; i++) {
+        if (fans[i].timeout) {
+            if ((HAL::timeInMilliseconds() - fans[i].time) > fans[i].timeout) {
+                EVENT_FAN_TIMEOUT(i, fans[i].target); 
+                Printer::setFanSpeed(fans[i].target, true, i);
             }
         }
     }
@@ -514,8 +515,8 @@ void Printer::setup() {
 
     //Quickly initialize our fans array
     PWMHandler* tempFans[] = FAN_LIST;
-    for(int i = 0; i < NUM_FANS; i++) {
-        fans[i] = {tempFans[i], 0, 0};
+    for (fast8_t i = 0; i < NUM_FANS; i++) {
+        fans[i] = { tempFans[i], 0, 0 };
     }
     HAL::analogStart();
 

--- a/src/Repetier/src/PrinterTypes/Printer.h
+++ b/src/Repetier/src/PrinterTypes/Printer.h
@@ -357,9 +357,7 @@ public:
     }
 #if AUTOMATIC_POWERUP
     static void enablePowerIfNeeded();
-#endif
-    /** Sets the pwm for the fan speed. Gets called by motion control or Commands::setFanSpeed. */
-    static void setFanSpeedDirectly(uint8_t speed, int fanId);
+#endif 
 
     /** For large machines, the nonlinear transformation can exceed integer 32bit range, so floating point math is needed. */
 
@@ -615,7 +613,8 @@ public:
     static void defaultLoopActions();
     static void setOrigin(float xOff, float yOff, float zOff);
     static int getFanSpeed(int fanId);
-    static void setFanSpeed(int speed, bool immediately, int fanId);
+    static void setFanSpeed(int speed, bool immediately, int fanId, int timeout = 0);
+    static void checkFanTimeouts();
 
 #if MAX_HARDWARE_ENDSTOP_Z || defined(DOXYGEN)
     static float runZMaxProbe();

--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -483,7 +483,15 @@ extern ServoInterface* servos[NUM_SERVOS];
 #define TRIM_FAN_PWM(x) static_cast<uint8_t>(static_cast<unsigned int>(x) * MAX_FAN_PWM / 255)
 #endif
 
-extern PWMHandler* fans[];
+struct fanController
+{
+    PWMHandler* fan;
+    millis_t time;
+    fast8_t target;
+    uint32_t timeout;
+};
+
+extern fanController fans[]; 
 // extern const uint8 osAnalogInputChannels[] PROGMEM;
 //extern uint8 osAnalogInputCounter[ANALOG_INPUTS];
 //extern uint osAnalogInputBuildup[ANALOG_INPUTS];

--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -111,6 +111,7 @@ void Commands::checkForPeriodicalActions(bool allowNewMoves) {
     HAL::pingWatchdog();
 #endif
 
+    Printer::checkFanTimeouts();
     // Report temperatures every second, so we do not need to send M105
     if (Printer::isAutoreportTemp()) {
         millis_t now = HAL::timeInMilliseconds();

--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -110,8 +110,7 @@ void Commands::checkForPeriodicalActions(bool allowNewMoves) {
 #if FEATURE_WATCHDOG
     HAL::pingWatchdog();
 #endif
-
-    Printer::checkFanTimeouts();
+ 
     // Report temperatures every second, so we do not need to send M105
     if (Printer::isAutoreportTemp()) {
         millis_t now = HAL::timeInMilliseconds();
@@ -129,6 +128,8 @@ void Commands::checkForPeriodicalActions(bool allowNewMoves) {
 #define IO_TARGET IO_TARGET_500MS
 #include "../io/redefine.h"
         EVENT_TIMER_500MS;
+        Printer::checkFanTimeouts();
+
     }
 #if DISPLAY_DRIVER != DRIVER_NONE
     GUI::update();

--- a/src/Repetier/src/communication/Commands.h
+++ b/src/Repetier/src/communication/Commands.h
@@ -36,7 +36,6 @@ public:
     static void waitUntilEndOfAllBuffers();
     static void waitMS(uint32_t wait);
     static void printTemperatures(bool showRaw = false);
-    static void setFanSpeed(int speed, bool immediately, int fanId); /// Set fan speed 0..255
     static void changeFeedrateMultiply(int factorInPercent);
     static void changeFlowrateMultiply(int factorInPercent);
     static void reportPrinterUsage();

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -418,13 +418,13 @@ void MCode_106(GCode* com) {
             p = static_cast<int>(com->P);
         } else if (Tool::getActiveTool()) {
             for (fast8_t i = 0; i < NUM_FANS; i++) {
-                if (Tool::getActiveTool()->usesSecondary(fans[i])) {
+                if (Tool::getActiveTool()->usesSecondary(fans[i].fan)) {
                     p = i;
                     break;
                 }
             }
         }
-        Printer::setFanSpeed(com->hasS() ? com->S : 255, false, p);
+        Printer::setFanSpeed(com->hasS() ? com->S : 255, false, p, com->hasO() ? static_cast<uint32_t>(com->O) : 0);
     }
 }
 
@@ -435,7 +435,7 @@ void MCode_107(GCode* com) {
             p = static_cast<int>(com->P);
         } else if (Tool::getActiveTool()) {
             for (fast8_t i = 0; i < NUM_FANS; i++) {
-                if (Tool::getActiveTool()->usesSecondary(fans[i])) {
+                if (Tool::getActiveTool()->usesSecondary(fans[i].fan)) {
                     p = i;
                     break;
                 }

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -423,8 +423,8 @@ void MCode_106(GCode* com) {
                     break;
                 }
             }
-        }
-        Printer::setFanSpeed(com->hasS() ? com->S : 255, false, p, com->hasO() ? static_cast<uint32_t>(com->O) : 0);
+        } 
+        Printer::setFanSpeed(com->hasS() ? com->S : 255, false, p, com->hasD() ? static_cast<uint32_t>(com->D) : 0);
     }
 }
 

--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -359,7 +359,7 @@ void __attribute__((weak)) menuControls(GUIAction action, void* data) {
 
 void __attribute__((weak)) menuFan(GUIAction action, void* data) {
     int id = reinterpret_cast<int>(data);
-    PWMHandler* pwm = fans[reinterpret_cast<int>(data)];
+    PWMHandler* pwm = fans[reinterpret_cast<int>(data)].fan;
     int32_t percent = (pwm->get() * 100) / 255;
     GUI::flashToStringLong(GUI::tmpString, PSTR("Fan @ Speed:"), id + 1);
     DRAW_LONG(GUI::tmpString, Com::tUnitPercent, percent);
@@ -373,7 +373,7 @@ void __attribute__((weak)) menuFans(GUIAction action, void* data) {
     GUI::menuTextP(action, PSTR("= Fans = "), true);
     GUI::menuBack(action);
     for (int i = 0; i < NUM_FANS; i++) {
-        PWMHandler* fan = fans[i];
+        PWMHandler* fan = fans[i].fan;
         int32_t percent = (fan->get() * 100) / 255;
         GUI::flashToStringLong(GUI::tmpString, PSTR("Fan @:"), i + 1);
         GUI::menuLong(action, GUI::tmpString, percent, menuFan, (void*)i, GUIPageType::FIXED_CONTENT);

--- a/src/Repetier/src/main.cpp
+++ b/src/Repetier/src/main.cpp
@@ -74,7 +74,7 @@ RepRap M Codes
 
 - M104 - Set extruder target temp
 - M105 - Read current temp
-- M106 S<speed> P<fan> I<ignore> - Fan on speed = 0..255, P = 0 or 1, 0 is default and can be omitted, I1 = Ignore M106/M107 from now on, I0 = disable ignore
+- M106 S<speed> P<fan> I<ignore> D<seconds> - Fan on speed = 0..255, P = 0 or 1, 0 is default and can be omitted, I1 = Ignore M106/M107 from now on, I0 = disable ignore, D<seconds> Adds a delay before actually setting the fan speed. 
 - M107 P<fan> - Fan off, P = 0 or 1, 0 is default and can be omitted
 - M109 - Wait for extruder current temp to reach target temp. Same params as M104
 - M114 S1 - Display current position, S1 = also write position in steps


### PR DESCRIPTION
Think this small fan delay/timeout functionality is useful to implement since more and more people are using enclosures that have fan/exhaust systems or more exotic configurations.

I chose the D parameter to avoid conflicting with any other firmware's gcode parameters (based off the [reprap g-code wiki](https://reprap.org/wiki/G-code#M106:_Fan_On))

Also added a EVENT_FAN_TIMEOUT(fanId, targetSpeed) event. Good for custom machines with custom actions (eg. motorized vents.)

Fan timeouts are checked with the 500ms timer inside Commands::checkForPeriodicalActions

I removed setFanSpeedDirectly as it seemed redundant and didn't see it in use anywhere else? I assumed it was a carry-over from V1. My apologies If you had plans for it.

<br/>
<i>(Updated)</i> Original Commit Desc: 

Adding a D\<seconds> parameter to the M106 command delays the adjustment of a fan's speed.

Example:
At the end of a print, run:
```
M106 P1 S255
M106 P1 S0 D180
```

^ The first M106 turns on fan P1 (enclosure fan, etc) at max.
The following M106 queues P1 to shut off after 180 seconds (3 minutes.)

You can queue any kind of S<speed> parameters to occur in the future using D\<seconds>

Any new M106 commands will overwrite the previously queued timeout. If no D parameter is included, the delay/timeout is simply cleared If there is one.

I've been using this for my printer's enclosure fans. At the end of a print my fans stay on for a short while to cool off the print. 

Sidenote: Removed duplicate setFanSpeed found in commands.cpp as well as setFanSpeedDirectly.