### PR TITLE
Implements M73 prgress command

### DIFF
--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -2268,6 +2268,10 @@ void Commands::processMCode(GCode* com) {
             }
         }
         break;
+    case 73: // M73 - Print status on display
+        UI_PROGRESS_UPD(com->hasP() ? com->P : -1,
+                        com->hasR() ? com->R : -1);
+        break;
     case 80: // M80 - ATX Power On
 #if PS_ON_PIN > -1
         Commands::waitUntilEndOfAllMoves();

--- a/src/ArduinoAVR/Repetier/DisplayList.h
+++ b/src/ArduinoAVR/Repetier/DisplayList.h
@@ -1963,6 +1963,7 @@ inline void uiCheckSlowKeys(uint16_t &action) {}
 #define UI_STATUS_UPD_F(status) {uid.setStatusP(status);uid.refreshPage();}
 #define UI_STATUS_RAM(status) uid.setStatus(status);
 #define UI_STATUS_UPD_RAM(status) {uid.setStatus(status);uid.refreshPage();}
+#define UI_PROGRESS_UPD(percent, eta) uid.setProgress(percent, eta);
 #define UI_ERROR(status) uid.setStatusP(PSTR(status),true);
 #define UI_ERROR_P(status) uid.setStatusP(status,true);
 #define UI_ERROR_UPD(status) {uid.setStatusP(PSTR(status),true);uid.refreshPage();}
@@ -1984,6 +1985,7 @@ inline void uiCheckSlowKeys(uint16_t &action) {}
 #define UI_STATUS_UPD(status) {}
 #define UI_STATUS_UPD_F(status) {}
 #define UI_STATUS_UPD_RAM(status) {}
+#define UI_PROGRESS_UPD(percent, eta) {}
 #define UI_CLEAR_STATUS {}
 #define UI_ERROR(msg) {}
 #define UI_ERROR_P(status) {}

--- a/src/ArduinoAVR/Repetier/ui.cpp
+++ b/src/ArduinoAVR/Repetier/ui.cpp
@@ -2202,6 +2202,47 @@ void UIDisplay::setStatus(const char *txt, bool error)
         Printer::setUIErrorMessage(true);
 }
 
+void UIDisplay::setProgress(int percent, int eta) {
+    static const char done_P[12][10] PROGMEM = {
+        {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+        {'.', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+        {'.', '.', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+        {'.', '.', '.', ' ', ' ', ' ', ' ', ' ', ' ', ' '},
+        {'.', '.', '.', '.', ' ', ' ', ' ', ' ', ' ', ' '},
+        {'.', '.', '.', '.', '.', ' ', ' ', ' ', ' ', ' '},
+        {'.', '.', '.', '.', '.', '.', ' ', ' ', ' ', ' '},
+        {'.', '.', '.', '.', '.', '.', '.', ' ', ' ', ' '},
+        {'.', '.', '.', '.', '.', '.', '.', '.', ' ', ' '},
+        {'.', '.', '.', '.', '.', '.', '.', '.', '.', ' '},
+        {'.', '.', '.', '.', '.', '.', '.', '.', '.', '.'},
+        {'.', '.', '.', '1', '0', '0', '.', '.', '.', '.'}
+    };
+    char status[21] = "[    --    ] Rm--:--";
+    
+    if (0 <= percent) {
+        if (percent >= 100) {
+            memcpy_P(status + 1, done_P[11], sizeof(done_P[0]));
+        } else {
+            memcpy_P(status + 1, done_P[(percent + 5) / 10], sizeof(done_P[0]));
+            status[5] = (percent < 10) ? ' ' : (percent / 10) | '0';
+            status[6] =                        (percent % 10) | '0';
+        }
+    }
+    
+    if (0 <= eta) {
+        unsigned h = eta / 60;
+        unsigned m = eta % 60;
+        
+        status[15] = (h < 10) ? ' ' : (h / 10) | '0';
+        status[16] =                  (h % 10) | '0';
+        status[18] =                  (m / 10) | '0';
+        status[19] =                  (m % 10) | '0';
+    }
+    
+    setStatus(status);
+    refreshPage();
+}
+
 const UIMenu *const ui_pages[UI_NUM_PAGES] PROGMEM = UI_PAGES;
 uint16_t nFilesOnCard;
 void UIDisplay::updateSDFileCount()

--- a/src/ArduinoAVR/Repetier/ui.h
+++ b/src/ArduinoAVR/Repetier/ui.h
@@ -892,6 +892,7 @@ public:
   void adjustMenuPos();
   void setStatusP(PGM_P txt, bool error = false);
   void setStatus(const char *txt, bool error = false);
+  void setProgress(int percent, int eta);
   inline void setOutputMaskBits(unsigned int bits)
   {
     outputMask |= bits;


### PR DESCRIPTION
Some slicers provides very good **time estimation and progress and exports it into GCODE** in the form of `M73` command.

This command provides progress in percentage as rgument `P` and remaining print time in minutes as argument `R`.

As there can be many types of displays, as most easy way seems to be to use message on display (same as command `M117`). Message with progress is displayed always when `M73` code is received and looks like in following example:

`[...74.   ] Rm 1:36`

Just note that `UIDisplay::setProgress` is here in the role of interface method, which may be modified in future to controll real progress bar on displays which supports that.