### PR TITLE
add LIGHT_SOURCE_PWM

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -85,6 +85,7 @@ bool Printer::failedMode = false;
 #define CASE_LIGHT_DEFAULT_ON 0
 #endif
 fast8_t Printer::caseLightMode = CASE_LIGHT_DEFAULT_ON;
+fast8_t Printer::caseLightBrightness = 255;
 
 #if defined(BEEPER_PIN) && BEEPER_PIN >= 0
 TonePacket toneQueueBuf[Printer::toneBufSize];
@@ -665,6 +666,9 @@ void Printer::reportCaseLightStatus() {
     }
     Com::printInfoF(PSTR("Case light mode:"));
     Com::print((int32_t)caseLightMode);
+    Com::println();
+    Com::printInfoF(PSTR("Case light brightness:"));
+    Com::print((int32_t)caseLightBrightness);
     Com::println();
 }
 

--- a/src/Repetier/src/PrinterTypes/Printer.h
+++ b/src/Repetier/src/PrinterTypes/Printer.h
@@ -286,6 +286,7 @@ public:
     static fast8_t breakLongCommand; // Set by M108 to stop long tasks
     static fast8_t wizardStackPos;
     static fast8_t caseLightMode;
+    static fast8_t caseLightBrightness; 
     static float progress;
     static wizardVar wizardStack[WIZARD_STACK_SIZE];
 

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -1162,7 +1162,10 @@ void MCode_350(GCode* com) {
 
 void MCode_355(GCode* com) {
     if (com->hasS()) {
-        Printer::caseLightMode = static_cast<uint8_t>(com->S);
+        Printer::caseLightMode = static_cast<fast8_t>(com->S);
+    }
+    if (com->hasP()) {
+        Printer::caseLightBrightness = constrain(static_cast<uint16_t>(com->P), 0, 255);
     }
     Printer::reportCaseLightStatus();
 }

--- a/src/Repetier/src/io/io_light.cpp
+++ b/src/Repetier/src/io/io_light.cpp
@@ -27,7 +27,7 @@ bool LightStoreBase::on() {
 LightStoreMonochrome::LightStoreMonochrome()
     : LightStoreBase() {}
 
-void LightStoreMonochrome::set(uint8_t _mode, uint8_t red, uint8_t green, uint8_t blue) {
+void LightStoreMonochrome::set(uint8_t _mode, uint8_t red, uint8_t green, uint8_t blue, uint8_t brightness) {
     mode = _mode;
 }
 
@@ -39,9 +39,86 @@ void LightStoreRGB::reset() {
 LightStoreRGB::LightStoreRGB()
     : LightStoreBase() {}
 
-void LightStoreRGB::set(uint8_t _mode, uint8_t _red, uint8_t _green, uint8_t _blue) {
+void LightStoreRGB::set(uint8_t _mode, uint8_t _red, uint8_t _green, uint8_t _blue, uint8_t brightness) {
     mode = _mode;
     redVal = _red;
     greenVal = _green;
     blueVal = _blue;
 }
+
+LightStorePWM::LightStorePWM()
+    : LightStoreBase() {}
+ 
+
+void LightStorePWM::set(uint8_t _mode, uint8_t _red, uint8_t _green, uint8_t _blue, uint8_t brightness) {
+    static uint8_t lastBrightness = 0;
+
+    if (mode != _mode || brightness != lastBrightness) {
+        // new mode or change in brightness needs a step recalculation
+        switch (mode = _mode) {
+        case LIGHT_STATE_BLINK_SLOW:
+            // Each fade takes 800ms..
+            fadeStep = computePWMStep(800, brightness);
+            break;
+        case LIGHT_STATE_BURST:
+            // Two fade pulses which take 100ms each, with ~600ms inbetween them.
+            fadeStep = computePWMStep(100, brightness);
+            break;
+        default:
+            // 400ms by default for light off/on/blink fast
+            fadeStep = computePWMStep(400, brightness);
+        }
+        lastBrightness = brightness;
+    }
+
+    if (mode == LIGHT_STATE_OFF) {
+        targetPWM = 0;
+    } else if (mode == LIGHT_STATE_ON) {
+        targetPWM = brightness;
+    } else if (mode == LIGHT_STATE_BURST) {
+        if (curPWM == targetPWM) {
+            if (counter == 5 || counter == 11) { 
+                targetPWM = brightness;
+            } else {
+                targetPWM = 0;
+            }
+
+            if (++counter > 11) {
+                counter = 0;
+            }
+        }
+    } else if (mode == LIGHT_STATE_BLINK_FAST) {
+        if (curPWM == targetPWM) {
+            if (targetPWM) {
+                targetPWM = 0;
+            } else {
+                targetPWM = brightness;
+            }
+        }
+    } else if (mode == LIGHT_STATE_BLINK_SLOW) {
+        if (curPWM == targetPWM) {
+            if (targetPWM) {
+                targetPWM = 0;
+            } else {
+                targetPWM = brightness;
+            }
+        }
+    } 
+}
+
+fast8_t LightStorePWM::updatePWM() {
+    millis_t curTime = HAL::timeInMilliseconds();
+    static millis_t lastUpdate = 0;
+
+    if ((curTime - lastUpdate) < refreshRateMS) {
+        return curPWM;
+    }
+    lastUpdate = curTime;
+
+    if (curPWM < targetPWM) {
+        curPWM = ((curPWM += rolloverCheck(fadeStep, true)) > targetPWM) ? targetPWM : curPWM;
+    } else if (curPWM > targetPWM) {
+        curPWM = ((curPWM -= rolloverCheck(fadeStep, false)) < targetPWM) ? targetPWM : curPWM;
+    }
+    return curPWM;
+} 

--- a/src/Repetier/src/io/io_light.h
+++ b/src/Repetier/src/io/io_light.h
@@ -24,7 +24,7 @@ from different sources like temperatures, pin states, pwm values, ...
 So there will never be a satisfying one catches all solution. Therefore we
 split light processing into 3 parts:
 - Light state store
-- State modifyer
+- State modifiers ("LIGHT_COND" etc)
 - Light driver
 
 Lights are updated in the 100ms timer. First state store resets light to off, white.
@@ -46,9 +46,11 @@ LIGHT_SOURCE_MONOCHROME(caseLightDriver, caseLightPin, caseLightState)
 Definies the following macros:
 
 #define LIGHT_STATE_MONOCHROME(name)
+#define LIGHT_STATE_PWM(name) 
 #define LIGHT_STATE_RGB(name)
-#define LIGHT_COND(state, cond, mode, red, green, blue)
+#define LIGHT_COND(state, cond, mode, red, green, blue, brightness) 
 #define LIGHT_SOURCE_MONOCHROME(name, output, state)
+#define LIGHT_SOURCE_PWM(name, output, state) 
 
 
 */
@@ -68,17 +70,25 @@ Definies the following macros:
 
 #undef LIGHT_STATE_MONOCHROME
 #undef LIGHT_STATE_RGB
+#undef LIGHT_STATE_PWM
 #undef LIGHT_SOURCE_MONOCHROME
+#undef LIGHT_SOURCE_PWM
 #undef LIGHT_COND
+
+#if IO_TARGET == IO_TARGET_PERIODICAL_ACTIONS 
+
+#define LIGHT_SOURCE_PWM(name, output, state) output.set(state.updatePWM());
+
+#endif
 
 #if IO_TARGET == IO_TARGET_100MS // 100ms
 
 #define LIGHT_STATE_MONOCHROME(name) name.reset();
 #define LIGHT_STATE_RGB(name) name.reset();
 #define LIGHT_SOURCE_MONOCHROME(name, output, state) output::set(state.on());
-#define LIGHT_COND(state, cond, mode, red, green, blue) \
+#define LIGHT_COND(state, cond, mode, red, green, blue, brightness) \
     if (cond) { \
-        state.set(mode, red, green, blue); \
+        state.set(mode, red, green, blue, brightness); \
     }
 
 #elif IO_TARGET == IO_TARGET_CLASS_DEFINITION // class
@@ -89,12 +99,12 @@ public:
         : mode(0)
         , counter(0) {}
     virtual void reset();
-    virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue) = 0;
+    virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue, uint8_t brightness) = 0;
     virtual bool on(); ///< Call only once per loop a sit manages blinking as well
     virtual uint8_t red() = 0;
     virtual uint8_t green() = 0;
     virtual uint8_t blue() = 0;
-
+    virtual uint8_t brightness() = 0;
 protected:
     fast8_t mode;
     fast8_t counter;
@@ -103,11 +113,11 @@ protected:
 class LightStoreMonochrome : public LightStoreBase {
 public:
     LightStoreMonochrome();
-    virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue) final;
+    virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue, uint8_t brightness) final;
     virtual uint8_t red() final { return 255; };
     virtual uint8_t green() final { return 255; };
     virtual uint8_t blue() final { return 255; };
-
+    virtual uint8_t brightness() final { return 255; };  
 private:
 };
 
@@ -115,21 +125,58 @@ class LightStoreRGB : public LightStoreBase {
 public:
     LightStoreRGB();
     virtual void reset() final;
-    virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue) final;
+    virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue, uint8_t brightness) final;
     virtual uint8_t red() final { return redVal; };
     virtual uint8_t green() final { return greenVal; };
     virtual uint8_t blue() final { return blueVal; };
-
+    virtual uint8_t brightness() final { return 255; };   
 private:
     uint8_t redVal;
     uint8_t greenVal;
     uint8_t blueVal;
 };
 
+class LightStorePWM : public LightStoreBase {
+public:
+    LightStorePWM();
+    virtual void reset() final {};
+    virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue, uint8_t brightness) final;
+    virtual uint8_t red() final { return 255; };
+    virtual uint8_t green() final { return 255; };
+    virtual uint8_t blue() final { return 255; };
+    virtual uint8_t brightness() final { return curPWM; };
+    virtual fast8_t updatePWM();
+
+    inline virtual fast8_t rolloverCheck(fast8_t step, bool add) final {
+        if (CPU_ARCH == ARCH_AVR) {
+            if (add) {
+                if ((255 - curPWM) < step) {
+                    return step = (255 - curPWM);
+                }
+            } else {
+                if (curPWM < step) {
+                    return step = curPWM;
+                }
+            }
+        }
+        return step;
+    }
+    inline virtual fast8_t computePWMStep(uint16_t durationMS, uint16_t condBrightness) final {
+        return constrain((refreshRateMS * condBrightness) / durationMS, 1, 255); 
+    }; 
+
+private: 
+    const uint8_t refreshRateMS = 30;
+    fast8_t targetPWM = 255; 
+    fast8_t curPWM = 255; 
+    fast8_t fadeStep;
+};
 #define LIGHT_STATE_MONOCHROME(name) \
     extern LightStoreMonochrome name;
 #define LIGHT_STATE_RGB(name) \
     extern LightStoreMonochrome name;
+#define LIGHT_STATE_PWM(name) \
+    extern LightStorePWM name;
 
 #elif IO_TARGET == IO_TARGET_DEFINE_VARIABLES // variable
 
@@ -137,11 +184,13 @@ private:
     LightStoreMonochrome name;
 #define LIGHT_STATE_RGB(name) \
     LightStoreMonochrome name;
+#define LIGHT_STATE_PWM(name) \
+    LightStorePWM name;
 
 #endif
 
 #ifndef LIGHT_COND
-#define LIGHT_COND(state, cond, mode, red, green, blue)
+#define LIGHT_COND(state, cond, mode, red, green, blue, brightness)
 #endif
 #ifndef LIGHT_STATE_MONOCHROME
 #define LIGHT_STATE_MONOCHROME(name)
@@ -149,6 +198,13 @@ private:
 #ifndef LIGHT_STATE_RGB
 #define LIGHT_STATE_RGB(name)
 #endif
+#ifndef LIGHT_STATE_PWM
+#define LIGHT_STATE_PWM(name)
+#endif
 #ifndef LIGHT_SOURCE_MONOCHROME
 #define LIGHT_SOURCE_MONOCHROME(name, output, state)
+#endif
+
+#ifndef LIGHT_SOURCE_PWM
+#define LIGHT_SOURCE_PWM(name, output, state)
 #endif

--- a/src/Repetier/src/main.cpp
+++ b/src/Repetier/src/main.cpp
@@ -155,6 +155,7 @@ Custom M Codes
 - M340 P<servoId> S<pulseInUS> R<autoOffIn ms>: servoID = 0..3, Servos are controlled by a pulse with normally between 500 and 2500 with 1500ms in center position. 0 turns servo off. R allows automatic disabling after a while.
 - M350 S<mstepsAll> X<mstepsX> Y<mstepsY> Z<mstepsZ> E<mstepsE0> P<mstespE1> : Set micro stepping on RAMBO board
 - M355 S<0/1/2/3/4> - Turn case light on/off/burst/blink fast/blink slow , no S = report status
+- M355 P<0..255>   - Change case light brightness if it's configured as a pwm light source.
 - M360 - show configuration
 - M400 - Wait until move buffers empty.
 - M401 - Store x, y and z position.


### PR DESCRIPTION
Small add-on for the io_lights module. PWM smoothed/fading light sources as well as M355 P<0..255> for general case light dimming.
Works with hardware and software PWM sources. 
The new macros are:
LIGHT_STATE_PWM(PWMCaseLightState)
LIGHT_SOURCE_PWM(caseLight, PWMCaseLight, PWMCaseLightState)
LIGHT_COND has a new 7th parameter for brightness (0-255) 
eg.
`LIGHT_COND(PWMCaseLightState, true, Printer::caseLightMode, 255, 255, 255, Printer::caseLightBrightness) `

The light fading takes place in the periodical actions timer and the default refresh rate is 30 milliseconds. Can be easily changed in io_light.h inside the LightStorePWM class. (beyond 50ms it becomes fairly choppy though.)

The duration of each fade transition is hard-coded at the moment in io_light.cpp, under the LightStorePWM::set method. (computePWMStep(durationMS, brightness);) 

computePWMStep isn't such a complicated function, though it's more-so future-proofing in case it's changed around. It's only called on brightness changes or mode changes.

 I added a small 8-bit int rollover constraint function for the pwm stepping to support AVR platforms later in the future. 