### PR TITLE
Due fix low frequency pwm

### DIFF
--- a/src/Repetier/src/boards/due/HAL.cpp
+++ b/src/Repetier/src/boards/due/HAL.cpp
@@ -289,14 +289,23 @@ static PWMChannel pwm_channel[8] = {
 static void computePWMDivider(uint32_t frequency, uint32_t& div, uint32_t& scale) {
     uint32_t factor = 1;
     div = 0;
+    if (frequency < 1) {
+        frequency = 1;
+    }
     do {
         scale = VARIANT_MCK / (frequency * factor);
         if (scale <= 65535) {
             return;
         }
-        div = factor;
-        factor <<= 1;
-    } while (factor <= 1024);
+        div++;
+    } while ((factor <<= 1) <= 1024);
+
+    if (scale > 65535) {
+        scale = 65535;
+    } 
+    if (div > 10) {
+        div = 10;
+    }  
 }
 
 // Try to initialize pinNumber as hardware PWM. Returns internal


### PR DESCRIPTION
this was slightly broken and was giving us the clock division rather than the clock divisor index. now works down to ~1.25hz on the due if necessary