### PR TITLE
Fix PWM light condition execution conflict

### DIFF
--- a/src/Repetier/src/io/io_light.cpp
+++ b/src/Repetier/src/io/io_light.cpp
@@ -50,34 +50,37 @@ LightStorePWM::LightStorePWM()
     : LightStoreBase() {}
 
 void LightStorePWM::set(uint8_t _mode, uint8_t _red, uint8_t _green, uint8_t _blue, uint8_t brightness) {
-    uint8_t lastBrightness = 0;
+    finalSetBrightness = brightness;
+    finalSetMode = _mode;
+}
 
-    if (mode != _mode || brightness != lastBrightness) {
+void LightStorePWM::reset() {
+    if (mode != finalSetMode || finalSetBrightness != lastBrightness) {
         // new mode or change in brightness needs a step recalculation
-        switch (mode = _mode) {
+        switch (mode = finalSetMode) {
         case LIGHT_STATE_BLINK_SLOW:
             // Each fade takes 800ms..
-            fadeStep = computePWMStep(800, brightness);
+            fadeStep = computePWMStep(800, finalSetBrightness);
             break;
         case LIGHT_STATE_BURST:
             // Two fade pulses which take 100ms each, with ~600ms inbetween them.
-            fadeStep = computePWMStep(100, brightness);
+            fadeStep = computePWMStep(100, finalSetBrightness);
             break;
         default:
             // 400ms by default for light off/on/blink fast
-            fadeStep = computePWMStep(400, brightness);
+            fadeStep = computePWMStep(400, finalSetBrightness);
         }
-        lastBrightness = brightness;
+        lastBrightness = finalSetBrightness;
     }
 
     if (mode == LIGHT_STATE_OFF) {
         targetPWM = 0;
     } else if (mode == LIGHT_STATE_ON) {
-        targetPWM = brightness;
+        targetPWM = finalSetBrightness;
     } else if (mode == LIGHT_STATE_BURST) {
         if (curPWM == targetPWM) {
             if (counter == 5 || counter == 11) {
-                targetPWM = brightness;
+                targetPWM = finalSetBrightness;
             } else {
                 targetPWM = 0;
             }
@@ -91,7 +94,7 @@ void LightStorePWM::set(uint8_t _mode, uint8_t _red, uint8_t _green, uint8_t _bl
             if (targetPWM) {
                 targetPWM = 0;
             } else {
-                targetPWM = brightness;
+                targetPWM = finalSetBrightness;
             }
         }
     } else if (mode == LIGHT_STATE_BLINK_SLOW) {
@@ -99,7 +102,7 @@ void LightStorePWM::set(uint8_t _mode, uint8_t _red, uint8_t _green, uint8_t _bl
             if (targetPWM) {
                 targetPWM = 0;
             } else {
-                targetPWM = brightness;
+                targetPWM = finalSetBrightness;
             }
         }
     }

--- a/src/Repetier/src/io/io_light.h
+++ b/src/Repetier/src/io/io_light.h
@@ -85,6 +85,8 @@ Definies the following macros:
 
 #define LIGHT_STATE_MONOCHROME(name) name.reset();
 #define LIGHT_STATE_RGB(name) name.reset();
+#define LIGHT_STATE_PWM(name) name.reset();
+
 #define LIGHT_SOURCE_MONOCHROME(name, output, state) output::set(state.on());
 #define LIGHT_COND(state, cond, mode, red, green, blue, brightness) \
     if (cond) { \
@@ -142,7 +144,7 @@ private:
 class LightStorePWM : public LightStoreBase {
 public:
     LightStorePWM();
-    virtual void reset() final {};
+    virtual void reset() final;
     virtual void set(uint8_t mode, uint8_t red, uint8_t green, uint8_t blue, uint8_t brightness) final;
     virtual uint8_t red() final { return 255; };
     virtual uint8_t green() final { return 255; };
@@ -171,10 +173,13 @@ public:
 private:
     const uint8_t refreshRateMS = 30;
     fast8_t targetPWM = 255;
-    fast8_t curPWM = 255;
+    fast8_t curPWM = 0;
     millis_t lastUpdate = 0;
     uint8_t lastBrightness = 0;
     fast8_t fadeStep;
+
+    uint8_t finalSetBrightness = 0;
+    fast8_t finalSetMode = 0;
 };
 #define LIGHT_STATE_MONOCHROME(name) \
     extern LightStoreMonochrome name;


### PR DESCRIPTION
I missed this (and the previous statics, thanks)
Last winning condition now sets the mode and brightness properly on the next reset