### PR TITLE
IO_TEMPERATURE_BETA

### DIFF
--- a/src/Repetier/src/io/io_temperature.h
+++ b/src/Repetier/src/io/io_temperature.h
@@ -42,6 +42,7 @@ IO_TEMPERATURE_TABLE(name,analog,table)
 #undef IO_TEMP_TABLE_NTC
 #undef IO_TEMP_TABLE_PTC
 #undef IO_TEMPERATURE_TABLE
+#undef IO_TEMPERATURE_BETA
 #undef IO_TEMPERATURE_MAX31855
 #undef IO_TEMPERATURE_MAX6675
 #undef IO_TEMPERATURE_FAKE
@@ -53,6 +54,7 @@ IO_TEMPERATURE_TABLE(name,analog,table)
 #define IO_TEMP_TABLE_NTC(name, dataname)
 #define IO_TEMP_TABLE_PTC(name, dataname)
 #define IO_TEMPERATURE_TABLE(name, analog, table)
+#define IO_TEMPERATURE_BETA(name, analog, beta, seriesResistance, thermistorR25, cCoefficient)
 #define IO_TEMPERATURE_MAX31855(name, spiDriver)
 #define IO_TEMPERATURE_MAX6675(name, spiDriver)
 
@@ -93,6 +95,30 @@ public:
     public: \
         float get() { \
             return table.interpolateFor(analog.get()); \
+        } \
+        bool isDefect() { \
+            int a = analog.get(); \
+            return a < 20 || a > 4075; \
+        } \
+    }; \
+    extern name##Class name;
+
+#define IO_TEMPERATURE_BETA(name, analog, beta, seriesResistance, thermistorR25, cCoefficient) \
+    class name##Class : public IOTemperature { \
+    public: \
+        float get() { \
+            const float invBeta = 1.0f / beta; \
+            const float invRoom = (1.0f / (25.0f - (-273.15))); \
+            const float logR25 = logf(thermistorR25); \
+            const float alpha = invRoom - invBeta * logR25 - cCoefficient * logR25 * logR25 * logR25; \
+            int aRead = analog.get(); \
+            aRead = aRead > 4094 ? 4094 : aRead < 1 ? 1 : aRead; \
+            float logResis = logf(seriesResistance * aRead / (4095 - aRead)); \
+            float steinharthart = alpha + invBeta * logResis; \
+            if (cCoefficient) { \
+                steinharthart += cCoefficient * (logResis * logResis * logResis); \
+            } \
+            return ((1.0f / steinharthart) - 273.15f); \
         } \
         bool isDefect() { \
             int a = analog.get(); \
@@ -241,6 +267,9 @@ public:
 #define IO_TEMPERATURE_TABLE(name, analog, table) \
     name##Class name;
 
+#define IO_TEMPERATURE_BETA(name, analog, beta, seriesResistance, thermistorR25, cCoefficient) \
+    name##Class name;
+
 #define IO_TEMPERATURE_MAX31855(name, spiDriver) \
     name##Class name;
 
@@ -266,6 +295,9 @@ public:
 #endif
 #ifndef IO_TEMPERATURE_TABLE
 #define IO_TEMPERATURE_TABLE(name, analog, table)
+#endif
+#ifndef IO_TEMPERATURE_BETA
+#define IO_TEMPERATURE_BETA(name, analog, beta, seriesResistance, thermistorR25, cCoefficient)
 #endif
 #ifndef IO_TEMPERATURE_MAX31855
 #define IO_TEMPERATURE_MAX31855(name, spiDriver)


### PR DESCRIPTION
Option for Steinhart-Hart/Beta generated thermistor readings. The C Coefficient is optional and can just be set 0 for a basic beta model instead. 

example:
IO_TEMPERATURE_BETA(TempExt2, IOAnalogExt2, 3950.0f, 5100.0f, 10000.0f, 0.0f)
IO_TEMPERATURE_BETA(name, analog, beta, seriesResistance, thermistorR25, cCoefficient)