### PR TITLE
Fix stepper timeout flood

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -308,9 +308,8 @@ void Printer::kill(uint8_t onlySteppers) {
         Motion1::motors[i]->disable();
     }
     Tool::disableMotors();
-#if defined(PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT) && PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT == 0
-    setAllSteppersDiabled();
-#endif 
+    setAllSteppersDisabled();
+
     FOR_ALL_AXES(i) {
 #if defined(PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT) && PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT == 1
         if (i == Z_AXIS) { 

--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -310,7 +310,15 @@ void Printer::kill(uint8_t onlySteppers) {
     Tool::disableMotors();
 #if defined(PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT) && PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT == 0
     setAllSteppersDiabled();
-#endif
+#endif 
+    FOR_ALL_AXES(i) {
+#if defined(PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT) && PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT == 1
+        if (i == Z_AXIS) { 
+            continue;
+        } 
+#endif 
+        Motion1::setAxisHomed(i, false);
+    }
     unsetHomedAll();
     if (!onlySteppers) {
         for (uint8_t i = 0; i < NUM_TOOLS; i++) {

--- a/src/Repetier/src/PrinterTypes/Printer.h
+++ b/src/Repetier/src/PrinterTypes/Printer.h
@@ -564,7 +564,7 @@ public:
     static INLINE bool areAllSteppersDisabled() {
         return flag0 & PRINTER_FLAG0_STEPPER_DISABLED;
     }
-    static INLINE void setAllSteppersDiabled() {
+    static INLINE void setAllSteppersDisabled() {
         flag0 |= PRINTER_FLAG0_STEPPER_DISABLED;
     }
     static INLINE void unsetAllSteppersDisabled() {


### PR DESCRIPTION
If PREVENT_Z_DISABLE_ON_STEPPER_TIMEOUT was set and the motors timed out, kill() would flood repetier server/host with temperature update prints until they crashed/froze
