### PR TITLE
[dev2] Set stallguard threshold per axis, use the value, and save in EEPROM

### DIFF
--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -762,7 +762,7 @@ void Commands::processMCode(GCode* com) {
     case 913: // Hybrid treshold
         MCode_Stepper(com);
         break;
-    case 914: // sensorless homing sensitivity
+    case 914: // Stallguard Sensitivity threshold (per axis)
         MCode_Stepper(com);
         break;
     case 998:

--- a/src/Repetier/src/drivers/stepper.cpp
+++ b/src/Repetier/src/drivers/stepper.cpp
@@ -393,12 +393,14 @@ void TMCStepper2130Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& 
                  || (name[0] == 'Z' && com.hasZ())
                  || (name[0] == 'E' && com.hasE())) { 
                     stallguardSensitivity = static_cast<int8_t>(com.S);
-                    driver->sgt(stallguardSensitivity);
 
                 // If no axis is named, assume all are to be updated
                 } else if (!com.hasX() && !com.hasY() && !com.hasZ() && !com.hasE()) {
                     stallguardSensitivity = static_cast<int8_t>(com.S);
                 }
+
+                // Update the driver setting
+                driver->sgt(stallguardSensitivity);
 #if STORE_MOTOR_STALL_SENSITIVITY
                     EEPROM::markChanged();
 #endif
@@ -665,12 +667,14 @@ void TMCStepper5160Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& 
                  || (name[0] == 'Z' && com.hasZ())
                  || (name[0] == 'E' && com.hasE())) { 
                     stallguardSensitivity = static_cast<int8_t>(com.S);
-                    driver->sgt(stallguardSensitivity);
 
                 // If no axis is named, assume all are to be updated
                 } else if (!com.hasX() && !com.hasY() && !com.hasZ() && !com.hasE()) {
                     stallguardSensitivity = static_cast<int8_t>(com.S);
                 }
+                
+                // Update the driver setting
+                driver->sgt(stallguardSensitivity);
 #if STORE_MOTOR_STALL_SENSITIVITY
                     EEPROM::markChanged();
 #endif
@@ -1202,13 +1206,14 @@ void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& 
                  || (name[0] == 'E' && com.hasE())) { 
                     stallguardSensitivity = static_cast<int8_t>(com.S);
 
-                    // Also update the driver setting
-                    driver->SGTHRS(stallguardSensitivity);
-
                 // If no axis is named, assume all are to be updated
                 } else if (!com.hasX() && !com.hasY() && !com.hasZ() && !com.hasE()) {
                     stallguardSensitivity = static_cast<int8_t>(com.S);
                 }
+                
+                // Update the driver setting
+                driver->SGTHRS(stallguardSensitivity);
+
 #if STORE_MOTOR_STALL_SENSITIVITY
                     EEPROM::markChanged();
 #endif

--- a/src/Repetier/src/drivers/stepper.h
+++ b/src/Repetier/src/drivers/stepper.h
@@ -68,6 +68,7 @@ public:
     // Allow having own settings e.g. current, microsteps
     virtual void eepromHandle() {}
     int motorIndex();
+    const char* motorName();
     void printMotorName();
 };
 


### PR DESCRIPTION
# Reasoning
M914 did not support per-axis modification of the stallguard threshold values, and also did not apply them to the motor drivers. We needed precise control over these values, and wanted them to be saved in EEPROM. For the former we had implemented a custom MCode, which is now no longer necessary.

I think the stallguard values were already intended to be saved to EEPROM, since the `STORE_MOTOR_STALL_SENSITIVITY` setting was already available. However, a change to these settings did not seem to be saved, and also not applied to the motors using the `TMC2130Stepper::sgt()` (and similar) methods.

# Changes
* Split out part of the `printMotorName()` function to be able to separately access the motor's name with minimal duplication
* Read the currently saved values out of EEPROM using `eepromHandle()` before altering any settings
* Changed setting of the `stallguardSensitivity` to a per-axis basis (if the current motor name is Xn, and X should be changed..)
* Added a case where if no axis is named, the behaviour is similar to before
* Apply the new `stallguardSensitivity` using `driver->sgt()` or `driver->SGTHRS()` where appropriate
* Marked the EEPROM values as being changed after setting `stallguardSensitivity`

# Usage of M914
| Command | Result |
| --- | --- | 
| `M914` | Print current threshold values per motor | 
| `M914 S5` | Set all stallguard thresholds to 5, apply to all motors, and save to EEPROM if `STORE_MOTOR_STALL_SENSITIVITY` is set. | 
| `M914 S5 X` | Set the stallguard threshold of the X axis to 5, apply this to all X axis motors, and save to EEPROM if `STORE_MOTOR_STALL_SENSITIVITY` is set. |
| `M914 S5 X Y E` | Set the stallguard thresholds for the X, Y and E axes to 5, apply, and optionally save. From Repetier-Host this seems to require sending `X0 Y0 E0` in order for the additional axes to be sent. | 

# Testing
The same code has been added to our customised version of dev2, and tested without any connected TMC2130 modules.