### PR TITLE
Z-Probe wait for probe if still activated

### DIFF
--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -235,9 +235,16 @@ float ZProbeHandler::runProbe() {
         deactivate();
     }
     if (ZProbe->update()) {
-        Com::printErrorFLN(PSTR("z-probe did not untrigger after going back to start position."));
-        Motion1::callAfterHomingOnSteppers();
-        return ILLEGAL_Z_PROBE;
+        millis_t startTime = HAL::timeInMilliseconds();
+        while (ZProbe->update() && ((HAL::timeInMilliseconds() - startTime) < 200)) {
+            Commands::checkForPeriodicalActions(false);
+        }
+
+        if (ZProbe->update()) {
+            Com::printErrorFLN(PSTR("z-probe did not untrigger after moving back to start position."));
+            Motion1::callAfterHomingOnSteppers();
+            return ILLEGAL_Z_PROBE;
+        }
     }
     Com::printF(Com::tZProbe, z, 3);
     Com::printF(Com::tSpaceXColon, Motion1::currentPosition[X_AXIS]);
@@ -527,9 +534,16 @@ float ZProbeHandler::runProbe() {
         deactivate();
     }
     if (ZProbe->update()) {
-        Com::printErrorFLN(PSTR("z-probe did not untrigger after going back to start position."));
-        Motion1::callAfterHomingOnSteppers();
-        return ILLEGAL_Z_PROBE;
+        millis_t startTime = HAL::timeInMilliseconds();
+        while (ZProbe->update() && ((HAL::timeInMilliseconds() - startTime) < 200)) {
+            Commands::checkForPeriodicalActions(false);
+        }
+
+        if (ZProbe->update()) {
+            Com::printErrorFLN(PSTR("z-probe did not untrigger after moving back to start position."));
+            Motion1::callAfterHomingOnSteppers();
+            return ILLEGAL_Z_PROBE;
+        }
     }
     Com::printF(Com::tZProbe, z, 3);
     Com::printF(Com::tSpaceXColon, Motion1::currentPosition[X_AXIS]);
@@ -815,9 +829,16 @@ float ZProbeHandler::runProbe() {
         deactivate();
     }
     if (ZProbe->update()) {
-        Com::printErrorFLN(PSTR("z-probe did not untrigger after going back to start position."));
-        Motion1::callAfterHomingOnSteppers();
-        return ILLEGAL_Z_PROBE;
+        millis_t startTime = HAL::timeInMilliseconds();
+        while (ZProbe->update() && ((HAL::timeInMilliseconds() - startTime) < 200)) {
+            Commands::checkForPeriodicalActions(false);
+        }
+
+        if (ZProbe->update()) {
+            Com::printErrorFLN(PSTR("z-probe did not untrigger after moving back to start position."));
+            Motion1::callAfterHomingOnSteppers();
+            return ILLEGAL_Z_PROBE;
+        }
     }
     Com::printF(Com::tZProbe, z, 3);
     Com::printF(Com::tSpaceXColon, Motion1::currentPosition[X_AXIS]);


### PR DESCRIPTION
Sometimes (especially with a close bed distance, fast z feedrate) a probe could fail if we end up moving back to our optimum bed height before it finishes retracting. 
This adds a timeout/wait check if it's still active when we move back. 
If it's still active after 200ms then it's a failure.
(I've read my bltouch taking 20-30ms)

Allows us to set the bed distance slightly closer for faster probing speeds 