### PR TITLE
Z-Probe mods compile fix

### DIFF
--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -747,7 +747,6 @@ void ZProbeHandler::showConfigMenu(GUIAction action) {
 uint16_t ZProbeHandler::eprStart;
 float ZProbeHandler::height;
 float ZProbeHandler::bedDistance;
-float ZProbeHandler::coating;
 float ZProbeHandler::offsetX;
 float ZProbeHandler::offsetY;
 float ZProbeHandler::speed;
@@ -985,7 +984,6 @@ float ZProbeHandler::runProbe() {
     // }
 #endif
     z += height;
-    z -= coating;
     z -= zCorr;
     /* DEBUG_MSG2_FAST("StartSteps", cPosSteps[Z_AXIS]);
     DEBUG_MSG2_FAST("EndSteps", tPosSteps[Z_AXIS]);
@@ -1063,7 +1061,6 @@ void ZProbeHandler::eepromReset() {
     speed = Z_PROBE_SPEED;
     offsetX = Z_PROBE_X_OFFSET;
     offsetY = Z_PROBE_Y_OFFSET;
-    coating = Z_PROBE_COATING;
     pauseHeaters = Z_PROBE_PAUSE_HEATERS;
 }
 

--- a/src/Repetier/src/drivers/zprobe.h
+++ b/src/Repetier/src/drivers/zprobe.h
@@ -14,6 +14,9 @@ public:
     static float optimumProbingHeight() { return 0; }
     static bool isActive() { return false; }
 
+    static void setXOffset(float val) { }
+    static void setYOffset(float val) { }
+
     static float getZProbeHeight() { return 0; };
     static void setZProbeHeight(float height) {};
 
@@ -52,13 +55,17 @@ public:
     static void deactivate();
     static float runProbe();
     static bool probingPossible();
-    static float xOffset();
-    static float yOffset();
     static void init();
     static void eepromHandle();
     static void eepromReset();
     static float optimumProbingHeight();
     static bool isActive() { return activated; }
+
+    static float xOffset();
+    static float yOffset();
+
+    static void setXOffset(float val) { offsetX = val; }
+    static void setYOffset(float val) { offsetY = val; }
 
     static float getZProbeHeight();
     static void setZProbeHeight(float height);
@@ -108,6 +115,9 @@ public:
     static float optimumProbingHeight();
     static bool isActive() { return activated; }
 
+    static void setXOffset(float val) { }
+    static void setYOffset(float val) { }
+
     static float getProbingTemp() { return probeTemperature; }
     static void setProbingTemp(float val) { probeTemperature = val; }
 
@@ -137,7 +147,6 @@ class ZProbeHandler {
     static uint16_t eprStart;
     static float height;
     static float bedDistance;
-    // static float coating;
     static float offsetX;
     static float offsetY;
     static float speed;


### PR DESCRIPTION
setXOffset/setYOffset were missing from default probe types
removed remnants of coating from the bltouch type