### PR TITLE
20x4 Displays - Clear unused rows

### DIFF
--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -734,6 +734,14 @@ void GUI::menuEnd(GUIAction action) {
         if (cursorRow[level] < 0) {
             cursorRow[level] = 0;
         }
+    } else if (action == GUIAction::DRAW) {
+        if (guiLine < UI_ROWS) {
+            bufClear();
+            const int count = (UI_ROWS - guiLine);
+            for (int i = 0; i < count; i++) {
+                printRow(guiLine++, buf);
+            }
+        }
     }
 }
 
@@ -1312,6 +1320,8 @@ void waitScreen(GUIAction action, void* data) {
 
         printRowCentered(0, text);
         GUI::bufClear();
+        printRow(1, GUI::buf);
+        printRow(2, GUI::buf);
         fast8_t len = refresh_counter % UI_COLS;
         for (fast8_t i = 0; i < len; i++) {
             GUI::bufAddChar('.');


### PR DESCRIPTION
Some menus with less than 4 menu items had ghosted text/rows from the previous menu (waitScreen did too)
I added a check to menuEnd to clear out any remaining rows if guiLine is less than our UI rows.
also added two row (1, 2) wipes to waitScreen which had a similar issue