### PR TITLE
Make a bare G92 reset coordinates.

### DIFF
--- a/src/ArduinoAVR/Repetier/Commands.cpp
+++ b/src/ArduinoAVR/Repetier/Commands.cpp
@@ -1791,6 +1791,10 @@ void Commands::processGCode(GCode* com) {
             Com::printF(PSTR(" Y_OFFSET:"), Printer::coordinateOffset[Y_AXIS], 3);
             Com::printFLN(PSTR(" Z_OFFSET:"), Printer::coordinateOffset[Z_AXIS], 3);
         }
+        if (! com->hasX() && ! com->hasY() && ! com->hasZ() && ! com->hasE()) {
+            Printer::setOrigin(0,0,0);
+            Com::printFLN(PSTR(" RESET X Y Y origin"));
+        }
     } break;
 #if DRIVE_SYSTEM == DELTA
     case 100: { // G100 Calibrate floor or rod radius

--- a/src/ArduinoDUE/Repetier/Commands.cpp
+++ b/src/ArduinoDUE/Repetier/Commands.cpp
@@ -1791,6 +1791,10 @@ void Commands::processGCode(GCode* com) {
             Com::printF(PSTR(" Y_OFFSET:"), Printer::coordinateOffset[Y_AXIS], 3);
             Com::printFLN(PSTR(" Z_OFFSET:"), Printer::coordinateOffset[Z_AXIS], 3);
         }
+        if (! com->hasX() && ! com->hasY() && ! com->hasZ() && ! com->hasE()) {
+            Printer::setOrigin(0,0,0);
+            Com::printFLN(PSTR(" RESET X Y Y origin"));
+        }
     } break;
 #if DRIVE_SYSTEM == DELTA
     case 100: { // G100 Calibrate floor or rod radius


### PR DESCRIPTION
Per https://reprap.org/wiki/G-code#G92:_Set_Position
    "A G92 without coordinates will reset all axes to zero on some
    firmware."

My specific use case was so that I could easily repeat parts in Laser
mode, using generated G code that assumed absolute coordinates, knowing
the origin of each part.