### PR TITLE
GUI Fix homing double clicks & scrolling clicks

### DIFF
--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -186,8 +186,10 @@ void GUI::okKey() {
 
 /** Check for button and store result in nextAction. */
 void GUI::handleKeypress() {
-    setEncoderA(ControllerEncA::get());
-    setEncoderB(ControllerEncB::get());
+    if (!ControllerClick::get()) {
+        setEncoderA(ControllerEncA::get());
+        setEncoderB(ControllerEncB::get());
+    }
     // debounce clicks
     if (nextAction == GUIAction::CLICK_PROCESSED || nextAction == GUIAction::BACK_PROCESSED) {
         millis_t timeDiff = HAL::timeInMilliseconds() - lastAction;
@@ -659,7 +661,9 @@ void directAction(GUIAction action, void* data) {
     int opt = reinterpret_cast<int>(data);
     switch (opt) {
     case GUI_DIRECT_ACTION_HOME_ALL:
-        Motion1::homeAxes(0);
+        if (!Printer::isHoming()) {
+            Motion1::homeAxes(0);
+        }
         break;
     case GUI_DIRECT_ACTION_HOME_X:
     case GUI_DIRECT_ACTION_HOME_Y:
@@ -668,7 +672,9 @@ void directAction(GUIAction action, void* data) {
     case GUI_DIRECT_ACTION_HOME_A:
     case GUI_DIRECT_ACTION_HOME_B:
     case GUI_DIRECT_ACTION_HOME_C:
-        Motion1::homeAxes(axisBits[opt - GUI_DIRECT_ACTION_HOME_X]);
+        if (!Printer::isHoming()) {
+            Motion1::homeAxes(axisBits[opt - GUI_DIRECT_ACTION_HOME_X]);
+        }
         break;
     case GUI_DIRECT_ACTION_FACTORY_RESET:
         EEPROM::restoreEEPROMSettingsFromConfiguration();


### PR DESCRIPTION
Added a homing flag check before running a home command from the menus and added a check to prevent us from scrolling while the encoder is being held down. 