### PR TITLE
STM32F4 Compile fixes

### DIFF
--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -607,7 +607,10 @@ extern int debugWaitLoop;
 
 #include "communication/Commands.h"
 #include "communication/Eeprom.h"
+
+#if SDSUPPORT
 #include "communication/CSVParser.h"
+#endif
 
 #if CPU_ARCH == ARCH_AVR
 #define DELAY1MICROSECOND __asm__("nop\n\t" \

--- a/src/Repetier/src/boards/STM32F4/HAL.cpp
+++ b/src/Repetier/src/boards/STM32F4/HAL.cpp
@@ -289,7 +289,7 @@ extern void TIMER_VECTOR(MOTION3_TIMER_NUM);
 extern void TIMER_VECTOR(PWM_TIMER_NUM);
 extern void TIMER_VECTOR(TONE_TIMER_NUM);
 
-#if NUM_SERVOS > 0
+#if NUM_SERVOS > 0 || NUM_BEEPERS > 0
 extern void servoOffTimer(HardwareTimer*);
 extern void TIMER_VECTOR(SERVO_TIMER_NUM);
 static uint32_t ServoPrescalerfactor = 20000;
@@ -825,11 +825,13 @@ void HAL::servoMicroseconds(uint8_t servoId, int microsec, uint16_t autoOff) {
     servoTimings[servoId] = microsec ? ((microsec * (servo->timer->getTimerClkFreq() / 1000000)) / ServoPrescalerfactor) - 1 : 0;
     servoAutoOff[servoId] = (microsec) ? (autoOff / 20) : 0;
 }
+#endif
 
 // ================== Interrupt handling ======================
 
 ServoInterface* analogServoSlots[4] = { nullptr, nullptr, nullptr, nullptr };
 void servoOffTimer(HardwareTimer* timer) {
+#if NUM_SERVOS > 0
     if (actServo) {
         actServo->disable();
         if (servoAutoOff[servoId]) {
@@ -854,6 +856,7 @@ void servoOffTimer(HardwareTimer* timer) {
             servo->tim->CCR1 = Servo2500;
         }
     }
+#endif
 // Add all generated servo interrupt handlers
 #undef IO_TARGET
 #define IO_TARGET IO_TARGET_SERVO_INTERRUPT
@@ -862,11 +865,12 @@ void servoOffTimer(HardwareTimer* timer) {
 
 // Servo timer Interrupt handler
 void TIMER_VECTOR(SERVO_TIMER_NUM) {
+#if NUM_SERVOS > 0
     if (actServo) {
         actServo->enable();
     }
-}
 #endif
+}
 
 /** \brief Timer interrupt routine to drive the stepper motors.
 */

--- a/src/Repetier/src/boards/STM32F4/HAL.h
+++ b/src/Repetier/src/boards/STM32F4/HAL.h
@@ -37,7 +37,9 @@
 #include "pins.h"
 #include "Print.h"
 #include "fastio.h"
+#if FEATURE_WATCHDOG
 #include <IWatchdog.h>
+#endif
 
 // Which I2C port to use?
 #ifndef WIRE_PORT
@@ -448,7 +450,9 @@ public:
 
     // Watchdog support
     inline static void startWatchdog() {
+#if FEATURE_WATCHDOG
         IWatchdog.begin(WATCHDOG_INTERVAL);
+#endif
     };
     inline static void stopWatchdog() { }
     inline static void pingWatchdog() {
@@ -460,6 +464,8 @@ public:
 #if NUM_SERVOS > 0
     static unsigned int servoTimings[4];
     static void servoMicroseconds(uint8_t servo, int ms, uint16_t autoOff);
+#else 
+    static void servoMicroseconds(uint8_t servo, int ms, uint16_t autoOff) { }
 #endif
 
     static void analogStart(void);


### PR DESCRIPTION
No servos but a beeper would cause a compile failure, watchdog, etc. 
Disabled SDSupport was still importing the CSVParser (which needs the sdfat library) 