### PR TITLE
GUI Hide disable button if heater isn't on

### DIFF
--- a/src/Repetier/src/drivers/heatManager.cpp
+++ b/src/Repetier/src/drivers/heatManager.cpp
@@ -20,6 +20,7 @@ void menuDisableTemperature(GUIAction action, void* data) {
 #if FEATURE_CONTROLLER != NO_CONTROLLER
     HeatManager* hm = reinterpret_cast<HeatManager*>(data);
     hm->setTargetTemperature(hm->getMinTemperature());
+    GUI::cursorRow[GUI::level]--;
 #endif
 }
 
@@ -301,8 +302,8 @@ void HeatManager::showControlMenu(GUIAction action) {
     } else {
         GUI::flashToStringLong(GUI::tmpString, PSTR("Set Temp: @°C"), static_cast<int32_t>(lroundf(targetTemperature)));
         GUI::menuSelectable(action, GUI::tmpString, menuSetTemperature, this, GUIPageType::FIXED_CONTENT);
+        GUI::menuSelectableP(action, PSTR("Disable"), menuDisableTemperature, this, GUIPageType::ACTION);
     }
-    GUI::menuSelectableP(action, PSTR("Disable"), menuDisableTemperature, this, GUIPageType::ACTION);
 #endif
 }
 
@@ -915,12 +916,12 @@ int HeatManagerDynDeadTime::eepromSizeLocal() {
     return 6 * 4;
 }
 
-void HeatManagerDynDeadTime::showControlMenu(GUIAction action) {
+/* void HeatManagerDynDeadTime::showControlMenu(GUIAction action) {
 #if FEATURE_CONTROLLER != NO_CONTROLLER
     GUI::flashToStringLong(GUI::tmpString, PSTR("Set Temp: @°C"), static_cast<int32_t>(lroundf(targetTemperature)));
     GUI::menuSelectable(action, GUI::tmpString, menuSetTemperature, this, GUIPageType::FIXED_CONTENT);
 #endif
-}
+} */
 
 void menuSetDDPTime1(GUIAction action, void* data) {
 #if FEATURE_CONTROLLER != NO_CONTROLLER

--- a/src/Repetier/src/drivers/heatManager.h
+++ b/src/Repetier/src/drivers/heatManager.h
@@ -303,7 +303,7 @@ public:
     void setDeadUp2(float val) { deadUp2 = val; }
     float getDeadDown2() { return deadDown2; }
     void setDeadDown2(float val) { deadDown2 = val; }
-    void showControlMenu(GUIAction action);
+    // void showControlMenu(GUIAction action);
     void showConfigMenu(GUIAction action);
     virtual bool hasConfigMenu() { return true; }
 };


### PR DESCRIPTION
I think this menuSelectableP may have been in the wrong spot. Added a cursorRow adjustment after the menu is clicked to return the cursor upwards

I commented out the DynDeadTime control menu like the PID's just for now since it was overriding the base class's.