### PR TITLE
ZProbe - Fix bltouch alarm loop

### DIFF
--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -1089,8 +1089,9 @@ bool ZProbeHandler::isAlarmOn() {
 }
 
 void ZProbeHandler::disableAlarmIfOn() {
-    while (isAlarmOn()) {
-        ZProbeServo.setPosition(2194, 0); // reset Alarm
+    millis_t startTime = HAL::timeInMilliseconds();
+    while (isAlarmOn() && (HAL::timeInMilliseconds() - startTime) < 1500) {
+        ZProbeServo.setPosition(2194, 0);
     }
     ZProbeServo.setPosition(1473, 0); // pin up
 }


### PR DESCRIPTION
Small find If the user's bltouch isn't wired up properly, or accidentally unplugged.