### PR TITLE
ZProbe - Control menu 

### DIFF
--- a/src/Repetier/src/controller/menu.h
+++ b/src/Repetier/src/controller/menu.h
@@ -14,5 +14,5 @@ extern void menuConfig(GUIAction action, void* data);
 extern void menuMoveE(GUIAction action, void* data);
 extern void menuFans(GUIAction action, void* data);
 extern void menuConfigAxis(GUIAction action, void* data);
-extern void menuConfigProbe(GUIAction action, void* data);
+extern void menuBreakLongCmd(GUIAction action, void* data);
 #endif

--- a/src/Repetier/src/controller/menu.h
+++ b/src/Repetier/src/controller/menu.h
@@ -14,5 +14,4 @@ extern void menuConfig(GUIAction action, void* data);
 extern void menuMoveE(GUIAction action, void* data);
 extern void menuFans(GUIAction action, void* data);
 extern void menuConfigAxis(GUIAction action, void* data);
-extern void menuBreakLongCmd(GUIAction action, void* data);
 #endif

--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -51,6 +51,7 @@ void ZProbeHandler::activate() {
     if (!Motion1::isAxisHomed(X_AXIS) || !Motion1::isAxisHomed(Y_AXIS)) {
         Motion1::homeAxes((Motion1::isAxisHomed(X_AXIS) ? 0 : 1) + (Motion1::isAxisHomed(Y_AXIS) ? 0 : 2));
     }
+    Printer::setZProbingActive(true);
     float cPos[NUM_AXES];
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, offsetX, offsetY, Z_PROBE_BORDER);
@@ -89,6 +90,7 @@ void ZProbeHandler::deactivate() {
     Motion1::setToolOffset(-tool->getOffsetX(), -tool->getOffsetY(), -tool->getOffsetZ());
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     activated = false;
+    Printer::setZProbingActive(false);
     if (pauseHeaters) {
         for (size_t i = 0; i < NUM_HEATERS; i++) {
             if (heaters[i]->isPaused()) {
@@ -406,6 +408,7 @@ void ZProbeHandler::activate() {
     if (!Motion1::isAxisHomed(X_AXIS) || !Motion1::isAxisHomed(Y_AXIS)) {
         Motion1::homeAxes((Motion1::isAxisHomed(X_AXIS) ? 0 : 1) + (Motion1::isAxisHomed(Y_AXIS) ? 0 : 2));
     }
+    Printer::setZProbingActive(true);
     float cPos[NUM_AXES];
     Tool* tool = Tool::getActiveTool();
     Motion1::copyCurrentOfficial(cPos);
@@ -462,6 +465,7 @@ void ZProbeHandler::deactivate() {
         hm->setTargetTemperature(activateTemperature);
     }
     activated = false;
+    Printer::setZProbingActive(false);
     if (pauseHeaters) {
         for (size_t i = 0; i < NUM_HEATERS; i++) {
             if (heaters[i]->isPaused()) {
@@ -771,6 +775,7 @@ void ZProbeHandler::activate() {
     if (!Motion1::isAxisHomed(X_AXIS) || !Motion1::isAxisHomed(Y_AXIS)) {
         Motion1::homeAxes((Motion1::isAxisHomed(X_AXIS) ? 0 : 1) + (Motion1::isAxisHomed(Y_AXIS) ? 0 : 2));
     }
+    Printer::setZProbingActive(true);
     float cPos[NUM_AXES];
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, offsetX, offsetY, Z_PROBE_BORDER);
@@ -819,6 +824,7 @@ void ZProbeHandler::deactivate() {
     Motion1::setToolOffset(-tool->getOffsetX(), -tool->getOffsetY(), -tool->getOffsetZ());
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     activated = false;
+    Printer::setZProbingActive(false);
     if (pauseHeaters) {
         for (size_t i = 0; i < NUM_HEATERS; i++) {
             if (heaters[i]->isPaused()) {

--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -1118,4 +1118,34 @@ void ZProbeHandler::showConfigMenu(GUIAction action) {
     GUI::menuFloatP(action, PSTR("X Offset    :"), ZProbeHandler::xOffset(), 1, menuProbeOffset, reinterpret_cast<void*>(0), GUIPageType::FIXED_CONTENT);
     GUI::menuFloatP(action, PSTR("Y Offset    :"), ZProbeHandler::yOffset(), 1, menuProbeOffset, reinterpret_cast<void*>(1), GUIPageType::FIXED_CONTENT);
 }
+
+void menuBLTouchAlarmRelease(GUIAction action, void* data) {
+    if (!Printer::isHoming() && !Printer::isZProbingActive()) {
+        ZProbeServo.setPosition(2194, 0);
+    }
+}
+void menuBLTouchStow(GUIAction action, void* data) {
+    if (!Printer::isHoming() && !Printer::isZProbingActive()) {
+        ZProbeServo.setPosition(1473, 0);
+    }
+}
+
+void menuBLTouchDeploy(GUIAction action, void* data) {
+    if (!Printer::isHoming() && !Printer::isZProbingActive()) {
+        ZProbeServo.setPosition(647, 0);
+    }
+}
+
+void menuBLTouchSelfTest(GUIAction action, void* data) {
+    if (!Printer::isHoming() && !Printer::isZProbingActive()) {
+        ZProbeServo.setPosition(1782, 0);
+    }
+}
+
+void ZProbeHandler::showControlMenu(GUIAction action) {
+    GUI::menuSelectableP(action, PSTR("Deploy Pin"), menuBLTouchDeploy, nullptr, GUIPageType::ACTION);
+    GUI::menuSelectableP(action, PSTR("Stow Pin"), menuBLTouchStow, nullptr, GUIPageType::ACTION);
+    GUI::menuSelectableP(action, PSTR("Self Test"), menuBLTouchSelfTest, nullptr, GUIPageType::ACTION);
+    GUI::menuSelectableP(action, PSTR("Alarm Release"), menuBLTouchAlarmRelease, nullptr, GUIPageType::ACTION);
+}
 #endif

--- a/src/Repetier/src/drivers/zprobe.h
+++ b/src/Repetier/src/drivers/zprobe.h
@@ -29,6 +29,9 @@ public:
     static void showConfigMenu(GUIAction action) { }
     static bool hasConfigMenu() { return false; }
 
+    static void showControlMenu(GUIAction action) { }
+    static bool hasControlMenu() { return false; }
+
     static bool getHeaterPause() { return false; }
     static void setHeaterPause(bool set) { }
 
@@ -78,6 +81,9 @@ public:
 
     static void showConfigMenu(GUIAction action);
     static bool hasConfigMenu() { return true; }
+
+    static void showControlMenu(GUIAction action) { };
+    static bool hasControlMenu() { return false; }
 
     static bool getHeaterPause() { return pauseHeaters; }
     static void setHeaterPause(bool set) { pauseHeaters = set; }
@@ -133,6 +139,9 @@ public:
     static void showConfigMenu(GUIAction action);
     static bool hasConfigMenu() { return true; }
 
+    static void showControlMenu(GUIAction action) { };
+    static bool hasControlMenu() { return false; }
+
     static bool getHeaterPause() { return pauseHeaters; }
     static void setHeaterPause(bool set) { pauseHeaters = set; }
 
@@ -185,6 +194,9 @@ public:
 
     static void showConfigMenu(GUIAction action);
     static bool hasConfigMenu() { return true; }
+
+    static void showControlMenu(GUIAction action);
+    static bool hasControlMenu() { return true; }
 
     static bool getHeaterPause() { return pauseHeaters; }
     static void setHeaterPause(bool set) { pauseHeaters = set; }


### PR DESCRIPTION
I've added the control menu for ZProbes though at the moment it's quite small with only two options (Run Single Probe, Run Autoleveling) unless you're using the BLTouch. +(Deploy, Stow, Alarm Release, Self Test).

I first used Leveling::measure to run the Autoleveling command and runProbe for the Single Probe,
But I saw that there's routines for eg. ZMax printers that need to run after measuring at the GCode_ functions. 
In effort to run those correctly as well, I'm calling Commands::executeGCode with a GCode instance:
```
GCode innerCode;
innerCode.source = GCodeSource::activeSource;
innerCode.internalCommand = true;
innerCode.setG(32); // G32
Commands::executeGCode(&innerCode);
```
Are you alright with me accessing/manipulating the GCode class/functions like this? Or should I look for another route? 