### PR TITLE
Async display init + skippable intro + show reboot warnings

### DIFF
--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -206,6 +206,16 @@ public:
     virtual void executeGCode(GCode* com);
 };
 
+enum class BootReason {
+    SOFTWARE_RESET = 0,
+    BROWNOUT = 1,
+    LOW_POWER = 2,
+    WATCHDOG_RESET = 3,
+    EXTERNAL_PIN = 4,
+    POWER_UP = 5,
+    UNKNOWN = -1
+};
+
 #include "io/temperature_tables.h"
 #include "Configuration.h"
 

--- a/src/Repetier/src/boards/SAMD51/HAL.cpp
+++ b/src/Repetier/src/boards/SAMD51/HAL.cpp
@@ -764,7 +764,7 @@ void HAL::importEEPROM() {
 // Print apparent cause of start/restart
 void HAL::showStartReason() {
     if (startReason == BootReason::BROWNOUT) {
-        Com::printInfoFLN(PSTR("Low power reset"));
+        Com::printInfoFLN(Com::tBrownOut);
     } else if (startReason == BootReason::WATCHDOG_RESET) {
         Com::printInfoFLN(Com::tWatchdog);
     } else if (startReason == BootReason::SOFTWARE_RESET) {

--- a/src/Repetier/src/boards/SAMD51/HAL.h
+++ b/src/Repetier/src/boards/SAMD51/HAL.h
@@ -338,6 +338,7 @@ public:
     static char virtualEeprom[EEPROM_BYTES];
     static bool wdPinged;
     static uint8_t i2cError;
+    static BootReason startReason;
 
     HAL();
     virtual ~HAL();
@@ -353,6 +354,7 @@ public:
     static void setHardwareFrequency(int id, uint32_t frequency);
     // do any hardware-specific initialization here
     static inline void hwSetup(void) {
+        updateStartReason();
 #if !FEATURE_WATCHDOG
         // Disable watchdog
         REG_WDT_CTRLA = 0;                   // Disable the WDT
@@ -622,6 +624,7 @@ public:
         RFSERIAL.flush();
     }
     static void setupTimer();
+    static void updateStartReason();
     static void showStartReason();
     static int getFreeRam();
     static void resetHardware();

--- a/src/Repetier/src/boards/STM32F4/HAL.cpp
+++ b/src/Repetier/src/boards/STM32F4/HAL.cpp
@@ -94,6 +94,7 @@ extern "C" char* sbrk(int i);
 char HAL::virtualEeprom[EEPROM_BYTES] = { 0 };
 bool HAL::wdPinged = true;
 uint8_t HAL::i2cError = 0;
+BootReason HAL::startReason = BootReason::UNKNOWN;
 
 enum class TimerUsage {
     UNUSED,
@@ -297,6 +298,7 @@ static uint32_t Servo2500 = 2500;
 #endif
 
 void HAL::hwSetup(void) {
+    updateStartReason();
 #if DEBUG_TIMING
     SET_OUTPUT(DEBUG_ISR_STEPPER_PIN);
     SET_OUTPUT(DEBUG_ISR_MOTION_PIN);
@@ -705,30 +707,43 @@ void HAL::importEEPROM() {
 
 #endif
 
-// Print apparent cause of start/restart
 void HAL::showStartReason() {
-    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+    if (startReason == BootReason::LOW_POWER) {
         Com::printInfoFLN(PSTR("Low power reset"));
-    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)) {
-        Com::printInfoFLN(Com::tWatchdog);
-    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
-        Com::printInfoFLN(PSTR("Independent watchdog reset"));
-    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
-        Com::printInfoFLN(PSTR("Software reset"));
-    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PORRST)) {
-        Com::printInfoFLN(Com::tPowerUp);
-    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
-        Com::printInfoFLN(PSTR("External reset pin reset"));
-    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+    } else if (startReason == BootReason::BROWNOUT) {
         Com::printInfoFLN(Com::tBrownOut);
+    } else if (startReason == BootReason::WATCHDOG_RESET) {
+        Com::printInfoFLN(Com::tWatchdog);
+    } else if (startReason == BootReason::SOFTWARE_RESET) {
+        Com::printInfoFLN(PSTR("Software reset"));
+    } else if (startReason == BootReason::POWER_UP) {
+        Com::printInfoFLN(Com::tPowerUp);
+    } else if (startReason == BootReason::EXTERNAL_PIN) {
+        Com::printInfoFLN(PSTR("External reset pin reset"));
     } else {
         Com::printInfoFLN(PSTR("Unknown reset reason"));
     }
-
+}
+void HAL::updateStartReason() {
+    if (__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST)) {
+        startReason = BootReason::LOW_POWER;
+    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+        startReason = BootReason::BROWNOUT;
+    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_WWDGRST)
+               || __HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)) {
+        startReason = BootReason::WATCHDOG_RESET;
+    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)) {
+        startReason = BootReason::SOFTWARE_RESET;
+    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PORRST)) {
+        startReason = BootReason::POWER_UP;
+    } else if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)) {
+        startReason = BootReason::EXTERNAL_PIN;
+    } else {
+        startReason = BootReason::UNKNOWN;
+    }
     // Clear all the reset flags or else they will remain set during future resets until system power is fully removed.
     __HAL_RCC_CLEAR_RESET_FLAGS();
 }
-
 // Return available memory
 int HAL::getFreeRam() {
     struct mallinfo memstruct = mallinfo();

--- a/src/Repetier/src/boards/STM32F4/HAL.h
+++ b/src/Repetier/src/boards/STM32F4/HAL.h
@@ -266,6 +266,7 @@ public:
     static char virtualEeprom[EEPROM_BYTES];
     static bool wdPinged;
     static uint8_t i2cError;
+    static BootReason startReason; 
 
     HAL();
     virtual ~HAL();
@@ -429,6 +430,7 @@ public:
         RFSERIAL.flush();
     }
     static void setupTimer();
+    static void updateStartReason();
     static void showStartReason();
     static int getFreeRam();
     static void resetHardware();

--- a/src/Repetier/src/boards/due/HAL.cpp
+++ b/src/Repetier/src/boards/due/HAL.cpp
@@ -631,7 +631,7 @@ void HAL::importEEPROM() {
 // Print apparent cause of start/restart
 void HAL::showStartReason() {
     if (startReason == BootReason::BROWNOUT) {
-        Com::printInfoFLN(PSTR("Low power reset"));
+        Com::printInfoFLN(Com::tBrownOut);
     } else if (startReason == BootReason::WATCHDOG_RESET) {
         Com::printInfoFLN(Com::tWatchdog);
     } else if (startReason == BootReason::SOFTWARE_RESET) {

--- a/src/Repetier/src/boards/due/HAL.h
+++ b/src/Repetier/src/boards/due/HAL.h
@@ -318,6 +318,7 @@ public:
     static char virtualEeprom[EEPROM_BYTES];
     static bool wdPinged;
     static uint8_t i2cError;
+    static BootReason startReason; 
 
     HAL();
     virtual ~HAL();
@@ -333,6 +334,7 @@ public:
     static void setHardwareFrequency(int id, uint32_t frequency);
     // do any hardware-specific initialization here
     static inline void hwSetup(void) {
+        updateStartReason();
 #if !FEATURE_WATCHDOG
         WDT_Disable(WDT); // Disable watchdog
 #endif
@@ -547,6 +549,7 @@ public:
 #endif
     }
     static void setupTimer();
+    static void updateStartReason();
     static void showStartReason();
     static int getFreeRam();
     static void resetHardware();

--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -288,9 +288,10 @@ void initializeLCD() {
     // before sending commands. Arduino can turn on way before 4.5V.
     // is this delay long enough for all cases??
 
-    if (GUI::bootState) {
+    if (GUI::bootState != GUIBootState::DISPLAY_INIT) {
         return;
     }
+
     SET_OUTPUT(UI_DISPLAY_D4_PIN);
     SET_OUTPUT(UI_DISPLAY_D5_PIN);
     SET_OUTPUT(UI_DISPLAY_D6_PIN);
@@ -719,13 +720,13 @@ void GUI::init() {
 }
 void GUI::processInit() {
     // Function called every 100ms (from GUI::update())
-    // if bootState isn't > 0
+    // If our bootstate is still initalizing
 
     // A 200-300ms delay from inital power up -> to
     // sending commands seems to be safe for these little
     // character displays, otherwise you might get gibberish/
     // glitched characters etc.
-    if (++init100msTicks < 3) { // 300 ms
+    if (++init100msTicks < 3 || bootState != GUIBootState::DISPLAY_INIT) { // 300 ms
         return;
     }
 
@@ -749,7 +750,7 @@ void GUI::processInit() {
     bufAddStringP(Com::tVendor);
     printRow(3, buf);
     lastRefresh = HAL::timeInMilliseconds() + UI_START_SCREEN_DELAY; // Show start screen 4s but will not delay start process
-    bootState = 1; // Switch to a skippable boot animation state
+    bootState = GUIBootState::IN_INTRO; // Switch to a skippable boot animation state
 }
 
 static fast8_t refresh_counter = 0;

--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -288,7 +288,7 @@ void initializeLCD() {
     // before sending commands. Arduino can turn on way before 4.5V.
     // is this delay long enough for all cases??
 
-    if (GUI::bootState != GUIBootState::DISPLAY_INIT) {
+    if (GUI::curBootState != GUIBootState::DISPLAY_INIT) {
         return;
     }
 
@@ -726,7 +726,7 @@ void GUI::processInit() {
     // sending commands seems to be safe for these little
     // character displays, otherwise you might get gibberish/
     // glitched characters etc.
-    if (++init100msTicks < 3 || bootState != GUIBootState::DISPLAY_INIT) { // 300 ms
+    if (++init100msTicks < 3 || curBootState != GUIBootState::DISPLAY_INIT) { // 300 ms
         return;
     }
 
@@ -750,7 +750,7 @@ void GUI::processInit() {
     bufAddStringP(Com::tVendor);
     printRow(3, buf);
     lastRefresh = HAL::timeInMilliseconds() + UI_START_SCREEN_DELAY; // Show start screen 4s but will not delay start process
-    bootState = GUIBootState::IN_INTRO; // Switch to a skippable boot animation state
+    curBootState = GUIBootState::IN_INTRO; // Switch to a skippable boot animation state
 }
 
 static fast8_t refresh_counter = 0;

--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -288,7 +288,7 @@ void initializeLCD() {
     // before sending commands. Arduino can turn on way before 4.5V.
     // is this delay long enough for all cases??
 
-    if (GUI::displayReady) {
+    if (GUI::bootState) {
         return;
     }
     SET_OUTPUT(UI_DISPLAY_D4_PIN);
@@ -719,7 +719,7 @@ void GUI::init() {
 }
 void GUI::processInit() {
     // Function called every 100ms (from GUI::update())
-    // if displayReady is not set.
+    // if bootState isn't > 0
 
     // A 200-300ms delay from inital power up -> to
     // sending commands seems to be safe for these little
@@ -730,7 +730,6 @@ void GUI::processInit() {
     }
 
     initializeLCD();
-    displayReady = true;
     handleKeypress();
     nextAction = GUIAction::NONE;
     callbacks[0] = startScreen;
@@ -750,6 +749,7 @@ void GUI::processInit() {
     bufAddStringP(Com::tVendor);
     printRow(3, buf);
     lastRefresh = HAL::timeInMilliseconds() + UI_START_SCREEN_DELAY; // Show start screen 4s but will not delay start process
+    bootState = 1; // Switch to a skippable boot animation state
 }
 
 static fast8_t refresh_counter = 0;

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -95,12 +95,10 @@ void GUI::init() {
     init100msTicks = 0;
 }
 void GUI::processInit() {
-    if (++init100msTicks < 1) { // 100 ms
+    if (++init100msTicks < 1 || bootState != GUIBootState::DISPLAY_INIT) { // 100 ms
         return;
     }
-    if (bootState) {
-        return;
-    }
+
     lcd.begin();
     handleKeypress();
     nextAction = GUIAction::NONE;
@@ -118,7 +116,7 @@ void GUI::processInit() {
         lcd.drawUTF8(20, 55, buf);
     } while (lcd.nextPage());
     lastRefresh = HAL::timeInMilliseconds() + UI_START_SCREEN_DELAY; // Show start screen 4s but will not delay start process
-    bootState = 1;
+    bootState = GUIBootState::IN_INTRO;
 }
 
 static fast8_t refresh_counter = 0;

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -90,14 +90,18 @@ U8G2_KS0108_128X64_2 lcd(DISPLAY_ROTATION, UI_DISPLAY_D0_PIN, UI_DISPLAY_D1_PIN,
 #endif
 #endif
 
-void GUI::init() { 
-    HAL::delayMilliseconds(50);
-    processInit();
+millis_t init100msTicks = 0;
+void GUI::init() {
+    init100msTicks = 0;
 }
-void GUI::processInit() { 
+void GUI::processInit() {
+    if (++init100msTicks < 1) { // 100 ms
+        return;
+    }
+    if (displayReady) {
+        return;
+    }
     lcd.begin();
-    displayReady = true;
-    
     handleKeypress();
     nextAction = GUIAction::NONE;
     callbacks[0] = startScreen;
@@ -113,6 +117,7 @@ void GUI::processInit() {
         bufAddStringP(PSTR(REPETIER_VERSION));
         lcd.drawUTF8(20, 55, buf);
     } while (lcd.nextPage());
+    displayReady = true;
     lastRefresh = HAL::timeInMilliseconds() + UI_START_SCREEN_DELAY; // Show start screen 4s but will not delay start process
 }
 

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -98,7 +98,7 @@ void GUI::processInit() {
     if (++init100msTicks < 1) { // 100 ms
         return;
     }
-    if (displayReady) {
+    if (bootState) {
         return;
     }
     lcd.begin();
@@ -117,8 +117,8 @@ void GUI::processInit() {
         bufAddStringP(PSTR(REPETIER_VERSION));
         lcd.drawUTF8(20, 55, buf);
     } while (lcd.nextPage());
-    displayReady = true;
     lastRefresh = HAL::timeInMilliseconds() + UI_START_SCREEN_DELAY; // Show start screen 4s but will not delay start process
+    bootState = 1;
 }
 
 static fast8_t refresh_counter = 0;

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -90,9 +90,14 @@ U8G2_KS0108_128X64_2 lcd(DISPLAY_ROTATION, UI_DISPLAY_D0_PIN, UI_DISPLAY_D1_PIN,
 #endif
 #endif
 
-void GUI::init() {
+void GUI::init() { 
     HAL::delayMilliseconds(50);
+    processInit();
+}
+void GUI::processInit() { 
     lcd.begin();
+    displayReady = true;
+    
     handleKeypress();
     nextAction = GUIAction::NONE;
     callbacks[0] = startScreen;

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -95,7 +95,7 @@ void GUI::init() {
     init100msTicks = 0;
 }
 void GUI::processInit() {
-    if (++init100msTicks < 1 || bootState != GUIBootState::DISPLAY_INIT) { // 100 ms
+    if (++init100msTicks < 1 || curBootState != GUIBootState::DISPLAY_INIT) { // 100 ms
         return;
     }
 
@@ -116,7 +116,7 @@ void GUI::processInit() {
         lcd.drawUTF8(20, 55, buf);
     } while (lcd.nextPage());
     lastRefresh = HAL::timeInMilliseconds() + UI_START_SCREEN_DELAY; // Show start screen 4s but will not delay start process
-    bootState = GUIBootState::IN_INTRO;
+    curBootState = GUIBootState::IN_INTRO;
 }
 
 static fast8_t refresh_counter = 0;

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -19,6 +19,7 @@ char GUI::buf[MAX_COLS + 1];                 ///< Buffer to build strings
 char GUI::tmpString[MAX_COLS + 1];           ///< Buffer to build strings
 fast8_t GUI::bufPos;                         ///< Pos for appending data
 bool GUI::textIsScrolling = false;           ///< Our selected row/text is now scrolling/anim
+bool GUI::displayReady = false;    		     ///< Ignores touches/UI actions until set
 #if SDSUPPORT
 char GUI::cwd[SD_MAX_FOLDER_DEPTH * LONG_FILENAME_LENGTH + 2] = { '/', 0 };
 uint8_t GUI::folderLevel = 0;
@@ -27,6 +28,8 @@ uint8_t GUI::folderLevel = 0;
 #if DISPLAY_DRIVER == DRIVER_NONE
 void GUI::init() { ///< Initialize display
     level = 0;
+}
+void GUI::processInit() { ///< Function repeatedly called if displayReady isn't true
 }
 
 void GUI::refresh() {
@@ -50,8 +53,12 @@ void GUI::resetMenu() { ///< Go to start page
 
 void GUI::update() {
 #if DISPLAY_DRIVER != DRIVER_NONE
-    millis_t timeDiff = HAL::timeInMilliseconds() - lastRefresh;
+    if (!displayReady) {
+        processInit();
+        return;
+    }
 
+    millis_t timeDiff = HAL::timeInMilliseconds() - lastRefresh;
     handleKeypress(); // Test for new keys
 
     if (nextAction == GUIAction::BACK) {

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -18,8 +18,8 @@ char GUI::status[MAX_COLS + 1];              ///< Status Line
 char GUI::buf[MAX_COLS + 1];                 ///< Buffer to build strings
 char GUI::tmpString[MAX_COLS + 1];           ///< Buffer to build strings
 fast8_t GUI::bufPos;                         ///< Pos for appending data
+GUIBootState GUI::curBootState = GUIBootState::DISPLAY_INIT;
 bool GUI::textIsScrolling = false;           ///< Our selected row/text is now scrolling/anim
-GUIBootState GUI::bootState = GUIBootState::DISPLAY_INIT;
 #if SDSUPPORT
 char GUI::cwd[SD_MAX_FOLDER_DEPTH * LONG_FILENAME_LENGTH + 2] = { '/', 0 };
 uint8_t GUI::folderLevel = 0;
@@ -29,7 +29,7 @@ uint8_t GUI::folderLevel = 0;
 void GUI::init() { ///< Initialize display
     level = 0;
 }
-void GUI::processInit() { ///< Function repeatedly called if bootState isn't true
+void GUI::processInit() { ///< Function repeatedly called if curBootState isn't at least IN_INTRO
 }
 
 void GUI::refresh() {
@@ -55,13 +55,13 @@ void GUI::update() {
 #if DISPLAY_DRIVER != DRIVER_NONE
     millis_t timeDiff = HAL::timeInMilliseconds() - lastRefresh;
 
-    if (bootState == GUIBootState::DISPLAY_INIT) { // Small delay before we start processing
+    if (curBootState == GUIBootState::DISPLAY_INIT) { // Small delay before we start processing
         processInit();
         return;
-    } else if (bootState == GUIBootState::IN_INTRO) { // Boot screen
+    } else if (curBootState == GUIBootState::IN_INTRO) { // Boot screen
         if (contentChanged || (timeDiff < 60000 && timeDiff > 1000)) { 
             // Skip if any key presses or timeout. 
-            bootState = GUIBootState::READY;
+            curBootState = GUIBootState::READY;
             lastRefresh = HAL::timeInMilliseconds();
             if (HAL::startReason == BootReason::WATCHDOG_RESET) {
                 GUI::setStatusP(PSTR("Reset by Watchdog!"), GUIStatusLevel::WARNING);

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -63,6 +63,11 @@ void GUI::update() {
             // Skip if any key presses or timeout. 
             bootState = GUIBootState::READY;
             lastRefresh = HAL::timeInMilliseconds();
+            if (HAL::startReason == BootReason::WATCHDOG_RESET) {
+                GUI::setStatusP(PSTR("Reset by Watchdog!"), GUIStatusLevel::WARNING);
+            } else if (HAL::startReason == BootReason::BROWNOUT) {
+                GUI::setStatusP(PSTR("Brownout reset!"), GUIStatusLevel::WARNING);
+            }
         }
     }
 

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -19,7 +19,7 @@ char GUI::buf[MAX_COLS + 1];                 ///< Buffer to build strings
 char GUI::tmpString[MAX_COLS + 1];           ///< Buffer to build strings
 fast8_t GUI::bufPos;                         ///< Pos for appending data
 bool GUI::textIsScrolling = false;           ///< Our selected row/text is now scrolling/anim
-ufast8_t GUI::bootState = 0;                 ///< Ignores touches/UI actions until > 0
+GUIBootState GUI::bootState = GUIBootState::DISPLAY_INIT;
 #if SDSUPPORT
 char GUI::cwd[SD_MAX_FOLDER_DEPTH * LONG_FILENAME_LENGTH + 2] = { '/', 0 };
 uint8_t GUI::folderLevel = 0;
@@ -55,13 +55,13 @@ void GUI::update() {
 #if DISPLAY_DRIVER != DRIVER_NONE
     millis_t timeDiff = HAL::timeInMilliseconds() - lastRefresh;
 
-    if (!bootState) { // Small delay before starting driver
+    if (bootState == GUIBootState::DISPLAY_INIT) { // Small delay before we start processing
         processInit();
         return;
-    } else if (bootState == 1) { // Boot screen
+    } else if (bootState == GUIBootState::IN_INTRO) { // Boot screen
         if (contentChanged || (timeDiff < 60000 && timeDiff > 1000)) { 
             // Skip if any key presses or timeout. 
-            bootState = 2;
+            bootState = GUIBootState::READY;
             lastRefresh = HAL::timeInMilliseconds();
         }
     }

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -139,7 +139,7 @@ public:
     static GUIPageType pageType[GUI_MAX_LEVEL];  ///< page type
     static millis_t lastRefresh;                 ///< Last refresh time
     static millis_t lastAction;                  ///< Last action time for autoreturn to display
-    static bool displayReady;                    ///< GUI is fully initalized & ready for input
+    static ufast8_t bootState;                   ///< GUI boot sequence, > 0 means ready for inputs. 
     static bool contentChanged;                  ///< set to true if forced refresh is wanted
     static char status[MAX_COLS + 1];            ///< Status Line
     static char buf[MAX_COLS + 1];               ///< Buffer to build strings

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -39,6 +39,12 @@
 #define GUI_DIRECT_ACTION_DITTO_8 33
 #define GUI_DIRECT_ACTION_TOGGLE_PROBE_PAUSE 34
 
+enum class GUIBootState {
+    DISPLAY_INIT = 0,
+    IN_INTRO = 1,
+    READY = 2
+};
+
 enum class GUIAction {
     NONE = 0,
     DRAW = 1,
@@ -139,7 +145,7 @@ public:
     static GUIPageType pageType[GUI_MAX_LEVEL];  ///< page type
     static millis_t lastRefresh;                 ///< Last refresh time
     static millis_t lastAction;                  ///< Last action time for autoreturn to display
-    static ufast8_t bootState;                   ///< GUI boot sequence, > 0 means ready for inputs. 
+    static GUIBootState bootState;               ///< GUI boot sequence state 
     static bool contentChanged;                  ///< set to true if forced refresh is wanted
     static char status[MAX_COLS + 1];            ///< Status Line
     static char buf[MAX_COLS + 1];               ///< Buffer to build strings

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -145,7 +145,7 @@ public:
     static GUIPageType pageType[GUI_MAX_LEVEL];  ///< page type
     static millis_t lastRefresh;                 ///< Last refresh time
     static millis_t lastAction;                  ///< Last action time for autoreturn to display
-    static GUIBootState bootState;               ///< GUI boot sequence state 
+    static GUIBootState curBootState;            ///< GUI boot sequence state 
     static bool contentChanged;                  ///< set to true if forced refresh is wanted
     static char status[MAX_COLS + 1];            ///< Status Line
     static char buf[MAX_COLS + 1];               ///< Buffer to build strings

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -139,6 +139,7 @@ public:
     static GUIPageType pageType[GUI_MAX_LEVEL];  ///< page type
     static millis_t lastRefresh;                 ///< Last refresh time
     static millis_t lastAction;                  ///< Last action time for autoreturn to display
+    static bool displayReady;                    ///< GUI is fully initalized & ready for input
     static bool contentChanged;                  ///< set to true if forced refresh is wanted
     static char status[MAX_COLS + 1];            ///< Status Line
     static char buf[MAX_COLS + 1];               ///< Buffer to build strings
@@ -173,12 +174,13 @@ public:
     static void setStatusP(FSTRINGPARAM(text), GUIStatusLevel lvl);
     static void setStatus(char* text, GUIStatusLevel lvl);
 
-    static void resetMenu(); ///< Go to start page
-    static void init();      ///< Initialize display
-    static void refresh();   ///< Refresh display
-    static void update();    ///< Calls refresh, checks buttons
-    static void pop();       ///< Go 1 level higher if possible
-    static void popBusy();   ///< Pop if waiting is on top
+    static void resetMenu();   ///< Go to start page
+    static void init();        ///< Initialize display
+    static void processInit(); ///< Continue initializing display if not ready
+    static void refresh();     ///< Refresh display
+    static void update();      ///< Calls refresh, checks buttons
+    static void pop();         ///< Go 1 level higher if possible
+    static void popBusy();     ///< Pop if waiting is on top
     static void push(GuiCallback cb, void* cData, GUIPageType tp);
     static void replace(GuiCallback cb, void* cData, GUIPageType tp);
     static bool isStickyPageType(GUIPageType t);


### PR DESCRIPTION
I've split the init for both of these displays so that a new function (processInit()) is called during boot-up every GUI::update(). Should help displays that might require a slightly longer delay without slowing down boot.

I later extended this slightly to let us skip the intro screen if we attempt to scroll/click while it's animating.
Three gui boot states: 
```
GUIBootState::DISPLAY_INIT
GUIBootState::IN_INTRO
GUIBootState::READY
```
(Active/current state stored in GUI::curBootState)

The final thing was an addition to our HAL's to store our last boot reason; and displays a warning if we've had a watchdog reset or brownout. The reboot enums are: 
```
enum class BootReason {
    SOFTWARE_RESET = 0,
    BROWNOUT = 1,
    LOW_POWER = 2,
    WATCHDOG_RESET = 3,
    EXTERNAL_PIN = 4,
    POWER_UP = 5,
    UNKNOWN = -1
};
```
defined in repetier.h.
Current  boot reason is stored in HAL::startReason.

One small thing: I hadn't noticed that SAMD's could return multiple reasons when I began with the other HAL's. In this case i've ordered the checks for SAMD by priority-ish for now. 