### PR TITLE
Feature Hide baudrate config if only connected to nativeUSB

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -524,13 +524,7 @@ void Printer::setup() {
 #endif
 #endif
 
-#if (defined(BLUETOOTH_SERIAL) && BLUETOOTH_SERIAL > 0) || CPU_ARCH == ARCH_AVR
-    constexpr bool isSerialUSB = false;
-#else
-    // GCC's __builtin_strncmp works with constexpr
-    constexpr bool isSerialUSB = (strncmp(PSTR(VALUE(RFSERIAL)), PSTR("SerialUSB"), sizeof("SerialUSB")) == 0);
-#endif
-    Printer::setNativeUSB(isSerialUSB);
+    Printer::setNativeUSB(!GCodeSource::hasBaudSources());
 
 #if SDSUPPORT
     //power to SD reader

--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -523,6 +523,15 @@ void Printer::setup() {
     Printer::setPowerOn(true);
 #endif
 #endif
+
+#if (defined(BLUETOOTH_SERIAL) && BLUETOOTH_SERIAL > 0) || CPU_ARCH == ARCH_AVR
+    constexpr bool isSerialUSB = false;
+#else
+    // GCC's __builtin_strncmp works with constexpr
+    constexpr bool isSerialUSB = (strncmp(PSTR(VALUE(RFSERIAL)), PSTR("SerialUSB"), sizeof("SerialUSB")) == 0);
+#endif
+    Printer::setNativeUSB(isSerialUSB);
+
 #if SDSUPPORT
     //power to SD reader
 #if SDPOWER > -1

--- a/src/Repetier/src/PrinterTypes/Printer.h
+++ b/src/Repetier/src/PrinterTypes/Printer.h
@@ -130,6 +130,7 @@ public:
 #define PRINTER_FLAG3_AUTOREPORT_TEMP 16
 #define PRINTER_FLAG3_SUPPORTS_STARTSTOP 32
 #define PRINTER_FLAG3_DOOR_OPEN 64
+#define PRINTER_FLAG3_NATIVE_USB 128
 
 // List of possible interrupt events (1-255 allowed)
 #define PRINTER_INTERRUPT_EVENT_JAM_DETECTED 1
@@ -534,7 +535,12 @@ public:
         flag2 = (b ? flag2 | PRINTER_FLAG2_JAMCONTROL_DISABLED : flag2 & ~PRINTER_FLAG2_JAMCONTROL_DISABLED);
         Com::printFLN(PSTR("Jam control disabled:"), b);
     }
-
+    static INLINE void setNativeUSB(bool yes) {
+        flag3 = (yes ? flag3 | PRINTER_FLAG3_NATIVE_USB : flag3 & ~PRINTER_FLAG3_NATIVE_USB); 
+    }
+    static INLINE bool isNativeUSB() { 
+        return flag3 & PRINTER_FLAG3_NATIVE_USB;
+    }
     static INLINE void toggleAnimation() {
         setAnimation(!isAnimation());
     }

--- a/src/Repetier/src/communication/Communication.h
+++ b/src/Repetier/src/communication/Communication.h
@@ -49,6 +49,7 @@ class GCodeSource {
 
 public:
     static GCodeSource* activeSource;
+    static GCodeSource* usbHostSource; 
     static void registerSource(GCodeSource* newSource);
     static void removeSource(GCodeSource* delSource);
     static void rotateSource();           ///< Move active to next source
@@ -56,6 +57,7 @@ public:
     static void prefetchAll();
     static void printAllFLN(FSTRINGPARAM(text));
     static void printAllFLN(FSTRINGPARAM(text), int32_t v);
+    static bool hasBaudSources();
     uint32_t lastLineNumber;
     uint8_t wasLastCommandReceivedAsBinary; ///< Was the last successful command in binary mode?
     millis_t timeOfLastDataPacket;

--- a/src/Repetier/src/communication/Eeprom.cpp
+++ b/src/Repetier/src/communication/Eeprom.cpp
@@ -109,9 +109,9 @@ void EEPROM::callHandle() {
 #if FEATURE_CONTROLLER != NO_CONTROLLER
     handleByte(EPR_SELECTED_LANGUAGE, Com::tLanguage, Com::selectedLanguage);
 #endif
-    if (strcmp_P(PSTR(VALUE(RFSERIAL)), PSTR("SerialUSB")) != 0) {
-        handleLong(EPR_BAUDRATE, Com::tEPRBaudrate, baudrate);
-    }
+    setSilent(Printer::isNativeUSB());
+    handleLong(EPR_BAUDRATE, Com::tEPRBaudrate, baudrate);
+    setSilent(false);
     handleLong(EPR_PRINTING_TIME, Com::tEPRPrinterActive, Printer::printingTime);
     handleLong(EPR_MAX_INACTIVE_TIME, Com::tEPRMaxInactiveTime, maxInactiveTime);
     handleLong(EPR_STEPPER_INACTIVE_TIME, Com::tEPRStopAfterInactivty, stepperInactiveTime);

--- a/src/Repetier/src/communication/Eeprom.cpp
+++ b/src/Repetier/src/communication/Eeprom.cpp
@@ -109,7 +109,9 @@ void EEPROM::callHandle() {
 #if FEATURE_CONTROLLER != NO_CONTROLLER
     handleByte(EPR_SELECTED_LANGUAGE, Com::tLanguage, Com::selectedLanguage);
 #endif
-    handleLong(EPR_BAUDRATE, Com::tEPRBaudrate, baudrate);
+    if (strcmp_P(PSTR(VALUE(RFSERIAL)), PSTR("SerialUSB")) != 0) {
+        handleLong(EPR_BAUDRATE, Com::tEPRBaudrate, baudrate);
+    }
     handleLong(EPR_PRINTING_TIME, Com::tEPRPrinterActive, Printer::printingTime);
     handleLong(EPR_MAX_INACTIVE_TIME, Com::tEPRMaxInactiveTime, maxInactiveTime);
     handleLong(EPR_STEPPER_INACTIVE_TIME, Com::tEPRStopAfterInactivty, stepperInactiveTime);

--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -316,6 +316,9 @@ void __attribute__((weak)) menuInfo(GUIAction action, void* data) {
     GUI::menuTextP(action, Com::tFirmwareCompiled);
     GUI::menuTextP(action, Com::tPrinterName);
     GUI::menuTextP(action, Com::tVendor);
+    if (Printer::isNativeUSB()) {
+        GUI::menuTextP(action, PSTR("Using Native USB"));
+    }
     GUI::menuEnd(action);
 }
 
@@ -757,7 +760,9 @@ void __attribute__((weak)) menuConfig(GUIAction action, void* data) {
     GUI::menuTextP(action, PSTR("= Configuration = "), true);
     GUI::menuBack(action);
 #if EEPROM_MODE > 0
-    GUI::menuLongP(action, PSTR("Baudrate:"), baudrate, menuBaudrate, nullptr, GUIPageType::FIXED_CONTENT);
+    if (!Printer::isNativeUSB()) {
+        GUI::menuLongP(action, PSTR("Baudrate:"), baudrate, menuBaudrate, nullptr, GUIPageType::FIXED_CONTENT);
+    }
 #endif
     FOR_ALL_AXES(i) {
         if (i == E_AXIS) {


### PR DESCRIPTION
I added/implemented grabbing the USB host into the new GCodeSource class, and now we track a pointer to the usbHostSource if we have one. 
If we only have a native USB connection this hides the baud configuration option from the eeprom and menu since baud rate doesn't apply to native. (well, technically it still gets passed down from the host actually, but doesn't do anything with it)
It's purposely _only_ hidden in case the user adds another serial source (TFT, bluetooth etc) it shouldn't corrupt eeprom nor lose their settings.

Unfortunately the way i'm detecting the usb host is a naive-ish pointer compare with the "SerialUSB" class since there's no API available. The class seems pretty consistent across arduino platforms though, I don't think it should cause trouble. 
I did #if it out for AVR platforms, since I don't think any AVR printer boards with native USB actively exist. (?)

PS. Do we have any MCode Command sent/official way to detect Repetier-Server/Repetier-Host instances from the firmware itself? :) (M539?)
It'd be useful to have a flag for it as well when connected I think. More server-firmware integration features like host rescue are cool. 