### PR TITLE
Fix HW TMC Stepper baud & IRQ priorities

### DIFF
--- a/src/Repetier/src/io/io_stepper.h
+++ b/src/Repetier/src/io/io_stepper.h
@@ -127,9 +127,11 @@
     name.eepromReserve();
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
     serial.begin(115200); \
+    serial.setInterruptPriority(5); \
     name.eepromReserve();
 #define STEPPER_TMC2209_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
-    serial.begin(500000); \
+    serial.begin(115200); \
+    serial.setInterruptPriority(5); \
     name.eepromReserve();
 #define STEPPER_TMC2209_SW_UART(name, stepPin, dirPin, enablePin, rxPin, txPin, rsense, microsteps, currentMillis, stealth, hybridSpeed, slaveAddr, stallSensitivity, fclk, minEndstop, maxEndstop) \
     name.eepromReserve();


### PR DESCRIPTION
I was trying to figure out why my TMC2209's had connection issues/dropouts on my main due printer with HW-USART. 
Never noticed serial was creating interrupts at 60KHz-ish, and at priority 0.
( I could have sworn the serial classes defaulted to 15? ) 
I adjusted the TMC2209's to 115200 baud and set their priority to 5. (I also set the TMC08's priority to the same)
No more connection issues, and my steppers seem slightly quieter/smoother. 
Think this default baud/priority should be good for everyone?
