### PR TITLE
printTemperatures remove unused showRaw parameter

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -342,7 +342,7 @@ void Printer::kill(uint8_t onlySteppers) {
     } else {
         UI_STATUS_UPD("Motors disabled");
     }
-    Commands::printTemperatures(false);
+    Commands::printTemperatures();
 }
 
 // This is for untransformed move to coordinates in printers absolute Cartesian space

--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -191,8 +191,7 @@ void Commands::waitUntilEndOfAllBuffers() {
     }
 }
 
-void Commands::printTemperatures(bool showRaw) {
-    int error;
+void Commands::printTemperatures() {
 #if NUM_TOOLS > 0
     Tool* t = Tool::getActiveTool();
     if (t != nullptr && t->supportsTemperatures()) {
@@ -221,20 +220,22 @@ void Commands::printTemperatures(bool showRaw) {
 }
 
 void Commands::changeFeedrateMultiply(int factor) {
-    if (factor < 25)
+    if (factor < 25) {
         factor = 25;
-    if (factor > 500)
+    } else if (factor > 500) {
         factor = 500;
+    }
     Printer::feedrate *= (float)factor / (float)Printer::feedrateMultiply;
     Printer::feedrateMultiply = factor;
     Com::printFLN(Com::tSpeedMultiply, factor);
 }
 
 void Commands::changeFlowrateMultiply(int factor) {
-    if (factor < 25)
+    if (factor < 25) {
         factor = 25;
-    if (factor > 200)
+    } else if (factor > 200) {
         factor = 200;
+    }
     Printer::extrudeMultiply = factor;
     // TODO: volumetric extrusion
     //if (Extruder::current->diameter <= 0)

--- a/src/Repetier/src/communication/Commands.h
+++ b/src/Repetier/src/communication/Commands.h
@@ -35,7 +35,7 @@ public:
     static void waitUntilEndOfAllMoves();
     static void waitUntilEndOfAllBuffers();
     static void waitMS(uint32_t wait);
-    static void printTemperatures(bool showRaw = false);
+    static void printTemperatures();
     static void changeFeedrateMultiply(int factorInPercent);
     static void changeFlowrateMultiply(int factorInPercent);
     static void reportPrinterUsage();

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -449,7 +449,7 @@ void __attribute__((weak)) MCode_104(GCode* com) {
 
 void __attribute__((weak)) MCode_105(GCode* com) {
     Com::writeToAll = false;
-    Commands::printTemperatures(com->hasX());
+    Commands::printTemperatures();
 }
 
 void __attribute__((weak)) MCode_106(GCode* com) {


### PR DESCRIPTION
compiling with LTO on the Due caused a weird compiler crash on this function. Looks like it's just because of the unused parameter.
(Did you still want a X show raw option?) 