### PR TITLE
Fix compiling under -O0

### DIFF
--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -199,11 +199,11 @@ extern void updateEndstops();
 class GCode;
 class ServoInterface {
 public:
-    virtual int getPosition();
-    virtual void setPosition(int pos, int32_t timeout);
-    virtual void enable();
-    virtual void disable();
-    virtual void executeGCode(GCode* com);
+    virtual int getPosition() = 0;
+    virtual void setPosition(int pos, int32_t timeout) = 0;
+    virtual void enable() = 0;
+    virtual void disable() = 0;
+    virtual void executeGCode(GCode* com) = 0;
 };
 
 enum class BootReason {

--- a/src/Repetier/src/io/io_beeper.h
+++ b/src/Repetier/src/io/io_beeper.h
@@ -79,7 +79,8 @@ public:
         , lastConditionStep(0)
         , curConditionStep(0)
         , curValidCondition(nullptr)
-        , lastValidCondition(nullptr) {}
+        , lastValidCondition(nullptr) { }
+    virtual ~BeeperSourceBase() { };
     inline fast8_t getHeadDist() {
         return !isPlaying() ? 0 : (toneHead >= toneTail ? (toneHead - toneTail) : (beepBufSize - toneTail + toneHead));
     }


### PR DESCRIPTION
Found -O0 generated some linker vtable issues:
IO_Beeper base needed a virtual destructor
ServoInterface's functions just needed to be pure virtual
