### PR TITLE
Fix emergency parser potentially wrong buffer size

### DIFF
--- a/src/Repetier/src/boards/due/HAL.h
+++ b/src/Repetier/src/boards/due/HAL.h
@@ -32,8 +32,13 @@
 
 // You can set different sizes if you want, but with binary mode it does not get faster
 #ifndef SERIAL_RX_BUFFER_SIZE
+#ifdef SERIAL_BUFFER_SIZE
+#define SERIAL_RX_BUFFER_SIZE SERIAL_BUFFER_SIZE
+#else
 #define SERIAL_RX_BUFFER_SIZE 128
 #endif
+#endif
+ 
 
 #ifndef HAL_H
 #define HAL_H

--- a/src/Repetier/src/communication/gcode.h
+++ b/src/Repetier/src/communication/gcode.h
@@ -35,7 +35,14 @@ enum class FirmwareState { NotBusy = 0,
 class SDCard;
 class Commands;
 class GCode;
+
+#ifndef SERIAL_IN_BUFFER
+#ifdef SERIAL_BUFFER_SIZE
+#define SERIAL_IN_BUFFER SERIAL_BUFFER_SIZE
+#else
 #define SERIAL_IN_BUFFER 128
+#endif
+#endif
 
 class SerialGCodeSource : public GCodeSource {
     Stream* stream;


### PR DESCRIPTION
I had an issue where my SERIAL_BUFFER_SIZE on my due wasn't set to the default 128. This sometimes made emergency parser commands not work/get missed if the server was auto configured for the wrong size

This makes sure SERIAL_IN_BUFFER is set to SERIAL_BUFFER_SIZE if defined. Seems to fix the issue, though I'm slightly confused if it's meant to be its own independent size?

I also did this for SERIAL_RX_BUFFER_SIZE defined in the due's HAL in case it's used somewhere in the future.