### PR TITLE
executeFString gcode serial bug fix (multiple extruders)

### DIFF
--- a/src/Repetier/src/communication/gcode.cpp
+++ b/src/Repetier/src/communication/gcode.cpp
@@ -1270,7 +1270,7 @@ void SerialGCodeSource::prefetchContent() {
         } else // ASCII command
         {
             char ch = commandReceiving[commandsReceivingWritePosition - 1];
-            if (ch == 0 || ch == '\n' || ch == '\r' || !GCodeSource::activeSource->isOpen() /*|| (!commentDetected && ch == ':')*/) // complete line read
+            if (ch == 0 || ch == '\n' || ch == '\r' || !isOpen()) //!GCodeSource::activeSource->isOpen() /*|| (!commentDetected && ch == ':')*/) // complete line read
             {
                 commandReceiving[commandsReceivingWritePosition - 1] = 0;
                 commentDetected = false;

--- a/src/Repetier/src/motion/MotionLevel1.cpp
+++ b/src/Repetier/src/motion/MotionLevel1.cpp
@@ -1574,7 +1574,8 @@ void Motion1::homeAxes(fast8_t axes) {
     Printer::setHoming(true);
 #if ZHOME_PRE_RAISE
     // float zAmountRaised = 0;
-    if (ZHOME_PRE_RAISE == 2 || Motion1::minAxisEndstops[Z_AXIS]->update()) {
+    if (ZHOME_PRE_RAISE == 2
+            || (Motion1::minAxisEndstops[Z_AXIS] && Motion1::minAxisEndstops[Z_AXIS]->update())) {
         if (!isAxisHomed(Z_AXIS) || currentPosition[Z_AXIS] + ZHOME_PRE_RAISE_DISTANCE < maxPos[Z_AXIS]) {
             setTmpPositionXYZ(IGNORE_COORDINATE, IGNORE_COORDINATE, ZHOME_PRE_RAISE_DISTANCE);
             moveRelativeByOfficial(tmpPosition, homingFeedrate[Z_AXIS], false);


### PR DESCRIPTION
If the tool had a start/end script -> executeFString creates a fake gcode object (without defining a source) ->
Commands::executeGCode updates the global activesource to this nullptr.  
We tried accessing that nullptr here in prefetch. 
I think we weren't meant to check the activesource here, but rather the source this is called in?

Edit: Actually taking another look at this, should the executeFString code source be set to flashSource as well? 

Sorry, I totally stalked that forum [post](https://forum.repetier.com/discussion/8084/dev2-tool-extruder-gcode-fail) and already had my debugger out. lol.  

Edit2: There was another specific possible toolscript crash I found with minAxisEndstops[Z_AXIS] if you had PRE_RAISE and a probe with a different class name (even with ENDSTOP_NONE(endstopZMin) set)