### PR TITLE
Baudrate config menu - update baudrate when exiting menu

### DIFF
--- a/src/Repetier/src/boards/SAMD51/HAL.h
+++ b/src/Repetier/src/boards/SAMD51/HAL.h
@@ -614,8 +614,10 @@ public:
     static inline void serialSetBaudrate(long baud) {
         // Serial.setInterruptPriority(1);
 #if defined(BLUETOOTH_SERIAL) && BLUETOOTH_SERIAL > 0
+        RFSERIAL2.end();
         RFSERIAL2.begin(baud);
 #endif
+        RFSERIAL.end();
         RFSERIAL.begin(baud);
     }
     static inline void serialFlush() {

--- a/src/Repetier/src/boards/STM32F1/HAL.h
+++ b/src/Repetier/src/boards/STM32F1/HAL.h
@@ -427,7 +427,15 @@ public:
     static inline void serialSetBaudrate(long baud) {
         // Serial.setInterruptPriority(1);
 #if defined(BLUETOOTH_SERIAL) && BLUETOOTH_SERIAL > 0
+        RFSERIAL2.end();
         RFSERIAL2.begin(baud);
+#endif
+#if defined(USBCON) && defined(USBD_USE_CDC) 
+        if (static_cast<Stream*>(&RFSERIAL) != &SerialUSB) { // When just updating the baudrate, don't restart USB.
+            RFSERIAL.end();
+        }
+#else
+        RFSERIAL.end();
 #endif
         RFSERIAL.begin(baud);
     }

--- a/src/Repetier/src/boards/STM32F4/HAL.h
+++ b/src/Repetier/src/boards/STM32F4/HAL.h
@@ -419,7 +419,15 @@ public:
     static inline void serialSetBaudrate(long baud) {
         // Serial.setInterruptPriority(1);
 #if defined(BLUETOOTH_SERIAL) && BLUETOOTH_SERIAL > 0
+        RFSERIAL2.end();
         RFSERIAL2.begin(baud);
+#endif
+#if defined(USBCON) && defined(USBD_USE_CDC) 
+        if (static_cast<Stream*>(&RFSERIAL) != &SerialUSB) {
+            RFSERIAL.end();
+        }
+#else
+        RFSERIAL.end();
 #endif
         RFSERIAL.begin(baud);
     }

--- a/src/Repetier/src/boards/due/HAL.h
+++ b/src/Repetier/src/boards/due/HAL.h
@@ -544,8 +544,12 @@ public:
 
     static inline void serialSetBaudrate(long baud) {
         Serial.setInterruptPriority(1);
+        if (static_cast<Stream*>(&RFSERIAL) != &SerialUSB) { // When just updating the baudrate, don't restart USB.
+            RFSERIAL.end();
+        }
         RFSERIAL.begin(baud);
 #if defined(BLUETOOTH_SERIAL) && BLUETOOTH_SERIAL > 0
+        RFSERIAL2.end();
         RFSERIAL2.begin(baud);
 #endif
     }

--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -299,14 +299,19 @@ void __attribute__((weak)) menuBaudrate(GUIAction action, void* data) {
         int32_t rate;
         do {
             rate = pgm_read_dword(&(baudrates[(uint8_t)p]));
-            if (rate == baudrate)
+            if (rate == baudrate) {
                 break;
+            }
             p++;
         } while (rate != 0);
-        if (rate == 0)
+        if (rate == 0) {
             p -= 2;
+        }
         if (GUI::handleLongValueAction(action, p, 0, 10, 1)) {
             baudrate = pgm_read_dword(&(baudrates[p]));
+        } else if (action == GUIAction::CLICK) {
+            // Update baudrates on click/pop
+            HAL::serialSetBaudrate(baudrate);
         }
     }
 }


### PR DESCRIPTION
I noticed changing the baudrate in the config menu didn't seem to actually change it when selected. 
I've changed it to update immediately once we exit the menu. 

To do this I've added serial end commands in each of the HAL's serialSetBaudrate to restart the serials at the new baudrate.
There's an included small check to avoid resetting the USB CDC connection. 
(I didn't add this check to the SAMD as I saw your previous commit where you excluded it from the gcodesource check)

It appears we also have a small bug where the baudrate currently gets reset to BAUDRATE on reboot. 
I *think* this is only happening with SDCard eeprom. I'll double check that when I get back. 