### PR TITLE
STM32F1/F4 - Fix tone timer prescaler

### DIFF
--- a/src/Repetier/src/boards/STM32F1/HAL.cpp
+++ b/src/Repetier/src/boards/STM32F1/HAL.cpp
@@ -1061,9 +1061,13 @@ void HAL::tone(uint32_t frequency) {
     if (frequency < 1) {
         return;
     }
-    // The HardwareTimer functions are kinda slow compared.
-    uint32_t autoReload = (F_CPU_TRUE / frequency) - 1;
-    LL_TIM_SetAutoReload(TIMER(TONE_TIMER_NUM), autoReload);
+    
+    // Faster timer reconfigurations to remove small gap between tone frequency changes
+    uint32_t autoReload = (F_CPU_TRUE / frequency); 
+    uint32_t prescale = (autoReload / 0x10000) + 1;
+    LL_TIM_SetPrescaler(TIMER(TONE_TIMER_NUM), prescale - 1); 
+    autoReload /= prescale;
+    LL_TIM_SetAutoReload(TIMER(TONE_TIMER_NUM), autoReload);  
     LL_TIM_OC_SetCompareCH1(TIMER(TONE_TIMER_NUM), ((autoReload + 1) * (Printer::toneVolume * 50)) / 10000);
     if (toneStopped) { // Only generate updates if the timer's dead.
         LL_TIM_GenerateEvent_UPDATE(TIMER(TONE_TIMER_NUM));

--- a/src/Repetier/src/boards/STM32F4/HAL.cpp
+++ b/src/Repetier/src/boards/STM32F4/HAL.cpp
@@ -1035,7 +1035,11 @@ void HAL::tone(uint32_t frequency) {
     if (frequency < 1) {
         return;
     }
-    uint32_t autoReload = (F_CPU_TRUE / frequency) - 1;
+    
+    uint32_t autoReload = (F_CPU_TRUE / frequency); 
+    uint32_t prescale = (autoReload / 0x10000) + 1;
+    LL_TIM_SetPrescaler(TIMER(TONE_TIMER_NUM), prescale - 1); 
+    autoReload /= prescale;
     LL_TIM_SetAutoReload(TIMER(TONE_TIMER_NUM), autoReload);
     LL_TIM_OC_SetCompareCH2(TIMER(TONE_TIMER_NUM), ((autoReload + 1) * (Printer::toneVolume * 50)) / 10000);
     if (toneStopped) { // Only generate updates if the timer's dead.


### PR DESCRIPTION
Some low frequencies weren't getting played properly due to the lack of a prescaler.