### PR TITLE
Add P<period ms> parameter to M155 autoreport

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -62,6 +62,7 @@ int Printer::maxLayer = -1;       // -1 = unknown
 char Printer::printName[21] = ""; // max. 20 chars + 0
 float Printer::progress = 0;
 millis_t Printer::lastTempReport = 0;
+millis_t Printer::autoReportPeriodMS = 1000; 
 int32_t Printer::printingTime = 0;
 
 uint32_t Printer::interval = 30000;      ///< Last step duration in ticks.

--- a/src/Repetier/src/PrinterTypes/Printer.h
+++ b/src/Repetier/src/PrinterTypes/Printer.h
@@ -263,7 +263,8 @@ public:
     static uint32_t interval;            ///< Last step duration in ticks.
     static uint32_t timer;               ///< used for acceleration/deceleration timing
     static uint32_t stepNumber;          ///< Step number in current move.
-    static millis_t lastTempReport;      ///< Time o flast temperature report for autoreport temperatures
+    static millis_t lastTempReport;      ///< Time of last temperature report for autoreport temperatures
+    static millis_t autoReportPeriodMS;  ///< Configurable delay between autoreports in ms. Default 1000ms. 
     static int32_t printingTime;         ///< Printing time in seconds
     static float extrudeMultiplyError;   ///< Accumulated error during extrusion
     static float extrusionFactor;        ///< Extrusion multiply factor

--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -114,7 +114,7 @@ void Commands::checkForPeriodicalActions(bool allowNewMoves) {
     HAL::pingWatchdog();
 #endif
 
-    // Report temperatures every second, so we do not need to send M105
+    // Report temperatures every autoReportPeriodMS (default 1000ms), so we do not need to send M105 
     if (Printer::isAutoreportTemp()) {
         millis_t now = HAL::timeInMilliseconds();
         if (now - Printer::lastTempReport > Printer::autoReportPeriodMS) {

--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -100,9 +100,10 @@ void Commands::checkForPeriodicalActions(bool allowNewMoves) {
 #undef IO_TARGET
 #define IO_TARGET IO_TARGET_PERIODICAL_ACTIONS
 #include "../io/redefine.h"
-
-    if (!executePeriodical)
+    if (!executePeriodical) {
         return; // gets true every 100ms
+    }
+
     executePeriodical = 0;
     EEPROM::timerHandler(); // store changes after timeout
     // include generic 100ms calls
@@ -116,7 +117,7 @@ void Commands::checkForPeriodicalActions(bool allowNewMoves) {
     // Report temperatures every second, so we do not need to send M105
     if (Printer::isAutoreportTemp()) {
         millis_t now = HAL::timeInMilliseconds();
-        if (now - Printer::lastTempReport > 1000) {
+        if (now - Printer::lastTempReport > Printer::autoReportPeriodMS) {
             Printer::lastTempReport = now;
             Commands::printTemperatures();
         }

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -772,8 +772,8 @@ void __attribute__((weak)) MCode_155(GCode* com) {
         millis_t period = constrain(com->P, 0, 10000);
         Printer::autoReportPeriodMS = (period <= 100) ? 0 : period;
         // Can't autoreport faster than 100ms, just set to 0 to use periodical's 100ms tick.
-    } else { // Reset period to 1s if P is omitted.
-        Printer::autoReportPeriodMS = 1000u;
+    } else { // Reset period to 1000ms if P is omitted.
+        Printer::autoReportPeriodMS = 1000;
     }
 }
 

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -768,6 +768,13 @@ void __attribute__((weak)) MCode_141(GCode* com) {
 void __attribute__((weak)) MCode_155(GCode* com) {
     Printer::setAutoreportTemp((com->hasS() && com->S != 0) || !com->hasS());
     Printer::lastTempReport = HAL::timeInMilliseconds();
+    if (com->hasP()) {
+        millis_t period = constrain(com->P, 0, 10000);
+        Printer::autoReportPeriodMS = (period <= 100) ? 0 : period;
+        // Can't autoreport faster than 100ms, just set to 0 to use periodical's 100ms tick.
+    } else { // Reset period to 1s if P is omitted.
+        Printer::autoReportPeriodMS = 1000u;
+    }
 }
 
 void __attribute__((weak)) MCode_163(GCode* com) {

--- a/src/Repetier/src/main.cpp
+++ b/src/Repetier/src/main.cpp
@@ -121,7 +121,7 @@ Custom M Codes
 - M118 <message> - Write message to host
 - M119 - Report endstop status
 - M140 S<temp> H1 O<offset> F1 - Set bed target temp, F1 makes a beep when temperature is reached the first time
-- M155 S<1/0> P<milliseconds> Enable/disable auto report temperatures. When enabled firmware will emit temperatures every second by default. Set P<ms> to change the autoreport frequency (100ms - 10s), resets to 1s if P is omitted.
+- M155 S<1/0> P<milliseconds> Enable/disable auto report temperatures. When enabled firmware will emit temperatures every second by default. Set P<ms> to change the autoreport frequency (100ms - 10s), resets to 1000ms if P is omitted.
 - M163 S<extruderNum> P<weight>  - Set weight for this mixing extruder drive
 - M164 S<virtNum> P<0 = dont store eeprom,1 = store to eeprom> - Store weights as virtual extruder S
 - M170 B<bedtemp> T<extruderid> S<extrudertemp> L0 - Set preset temperatures for extruder (T+S) or bed (B) or list settings (L0)

--- a/src/Repetier/src/main.cpp
+++ b/src/Repetier/src/main.cpp
@@ -121,7 +121,7 @@ Custom M Codes
 - M118 <message> - Write message to host
 - M119 - Report endstop status
 - M140 S<temp> H1 O<offset> F1 - Set bed target temp, F1 makes a beep when temperature is reached the first time
-- M155 S<1/0> Enable/disable auto report temperatures. When enabled firmware will emit temperatures every second.
+- M155 S<1/0> P<milliseconds> Enable/disable auto report temperatures. When enabled firmware will emit temperatures every second by default. Set P<ms> to change the autoreport frequency (100ms - 10s), resets to 1s if P is omitted.
 - M163 S<extruderNum> P<weight>  - Set weight for this mixing extruder drive
 - M164 S<virtNum> P<0 = dont store eeprom,1 = store to eeprom> - Store weights as virtual extruder S
 - M170 B<bedtemp> T<extruderid> S<extrudertemp> L0 - Set preset temperatures for extruder (T+S) or bed (B) or list settings (L0)


### PR DESCRIPTION
Quickly added a P<milliseconds> parameter to let us change the rate we get auto temperature reports (for debugging etc). 
Minimum is 100ms, max is 10 seconds. 
Will always safely reset back to 1 second if P is omitted for best compatibility/host reconnects/errors etc.