### PR TITLE
STM32F1 Adjust ADC sample rate

### DIFF
--- a/src/Repetier/src/boards/STM32F1/HAL.cpp
+++ b/src/Repetier/src/boards/STM32F1/HAL.cpp
@@ -540,7 +540,7 @@ void HAL::analogStart(void) {
         return;
     }
     ADC_ChannelConfTypeDef sConfig = { 0 };
-    sConfig.SamplingTime = ADC_SAMPLETIME_41CYCLES_5;
+    sConfig.SamplingTime = ADC_SAMPLETIME_239CYCLES_5;
 
     for (int i = 0; i < numAnalogInputs; i++) {
         sConfig.Channel = analogValues[i].channel;
@@ -555,7 +555,7 @@ void HAL::analogStart(void) {
 
     RCC_PeriphCLKInitTypeDef PeriphClkInit = { 0 };
     PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC;
-    PeriphClkInit.AdcClockSelection = RCC_ADCPCLK2_DIV4;
+    PeriphClkInit.AdcClockSelection = RCC_ADCPCLK2_DIV8;
     HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
 
     HAL_ADCEx_Calibration_Start(&AdcHandle);


### PR DESCRIPTION
I previously set the ADC sample time/rate far too fast. Had a lot of jitter/bouncing at low temperatures. Guess the capacitors on those pins didn't have a chance to properly discharge. Temps much cleaner now.