### PR TITLE
Fix extra cold extrusion warnings on moves

### DIFF
--- a/src/Repetier/src/motion/MotionLevel1.cpp
+++ b/src/Repetier/src/motion/MotionLevel1.cpp
@@ -605,6 +605,7 @@ void Motion1::setTmpPositionXYZE(float x, float y, float z, float e) {
 
 // Move with coordinates in official coordinates (before offset, transform, ...)
 bool Motion1::moveByOfficial(float coords[NUM_AXES], float feedrate, bool secondaryMove) {
+    bool movingEAxis = (coords[E_AXIS] != currentPosition[E_AXIS]);
     Printer::unparkSafety();
     FOR_ALL_AXES(i) {
         if (coords[i] != IGNORE_COORDINATE) {
@@ -620,8 +621,8 @@ bool Motion1::moveByOfficial(float coords[NUM_AXES], float feedrate, bool second
 #endif
     ) { // ignore
 #if MIN_EXTRUDER_TEMP > MAX_ROOM_TEMPERATURE
-        if (coords[E_AXIS] != IGNORE_COORDINATE && !Printer::debugDryrun()) {
-            Com::printWarningFLN(Com::tColdExtrusionPrevented);
+        if (movingEAxis && coords[E_AXIS] != IGNORE_COORDINATE && !Printer::debugDryrun()) {
+            Com::printWarningFLN(Com::tColdExtrusionPrevented); 
         }
 #endif
         destinationPositionTransformed[E_AXIS] = currentPositionTransformed[E_AXIS];
@@ -787,6 +788,7 @@ void Motion1::setToolOffset(float ox, float oy, float oz) {
 
 // Move to the printer coordinates (after offset, transform, ...)
 bool Motion1::moveByPrinter(float coords[NUM_AXES], float feedrate, bool secondaryMove) {
+    bool movingEAxis = (coords[E_AXIS] != destinationPositionTransformed[E_AXIS]);
     Printer::unparkSafety();
     FOR_ALL_AXES(i) {
         if (coords[i] == IGNORE_COORDINATE) {
@@ -802,7 +804,7 @@ bool Motion1::moveByPrinter(float coords[NUM_AXES], float feedrate, bool seconda
 #endif
     ) {
 #if MIN_EXTRUDER_TEMP > MAX_ROOM_TEMPERATURE
-        if (coords[E_AXIS] != IGNORE_COORDINATE && !Printer::debugDryrun()) {
+        if (movingEAxis && coords[E_AXIS] != IGNORE_COORDINATE && !Printer::debugDryrun()) {
             Com::printWarningFLN(Com::tColdExtrusionPrevented);
         }
 #endif


### PR DESCRIPTION
Added a quick check to make sure we're moving the E axis before displaying the new cold extrusion warning.

Looks like we have a few places at the moment where we do something like oldCoordinates[E_AXIS] = currentPosition[E_AXIS] rather than IGNORE_COORDINATE before the moveByOfficial/Printer calls

Alternatively we could update those places to use IGNORE_COORDINATE i think.
(Wasn't sure if they may have been intentional and didn't want to break them.)

Edit: Actually, it looks like there's not really that many places that happens. Mostly in ZProbe.
Want me to just fix the responsible moveByX calls without IGNORE_COORDINATE on the E_AXIS and update this pull instead? 