### PR TITLE
Update .gitattributes (Fix repo's language stats)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,11 @@
 *.jpg binary
 *.db binary
 *.stl binary
+
+
+api-doc/html/* linguist-documentation
+doc/* linguist-documentation 
+src/Repetier/src/u8g2/* linguist-vendored
+
+*.cpp linguist-language=cpp 
+*.c linguist-language=c


### PR DESCRIPTION
Small OCD fix for the repo's languages bar statistic. Now shows the project/source as mostly C++/C.

Marked u8g2 as vendored so it's ignored. (It's a LOT of lines in C and overwhelms the stats)
Marked docs/html as documentation, ignored as well.

(Maybe you could also update the main V1 branch .gitattribute too)
