### PR TITLE
Fix STM32F1 compiling - missing setInterruptPriority

### DIFF
--- a/src/Repetier/src/io/io_stepper.h
+++ b/src/Repetier/src/io/io_stepper.h
@@ -125,7 +125,7 @@
     name.eepromReserve();
 #define STEPPER_TMC5160_SW_SPI(name, stepPin, dirPin, enablePin, mosiPin, misoPin, sckPin, csPin, rsense, chainPos, microsteps, currentMillis, stealth, hybridSpeed, stallSensitivity, fclk, minEndstop, maxEndstop) \
     name.eepromReserve();
-#if defined(SAMD51_BOARD)
+#if defined(SAMD51_BOARD) || defined(ARDUINO_ARCH_STM32)
 #define STEPPER_TMC2208_HW_UART(name, stepPin, dirPin, enablePin, serial, rsense, microsteps, currentMillis, stealth, hybridSpeed, fclk, minEndstop, maxEndstop) \
     serial.begin(115200); \
     name.eepromReserve();


### PR DESCRIPTION
Ran into this too while setting up my HW TMC's. 
STM32Duino has setInterruptPriority for software serial and timers, but not HW serial. Didn't know that.

Maybe I shouldn't have added it here since it seems only the Due has that function? 