### PR TITLE
Fix HEAT_MANAGER_DYN_DEAD_TIME wrong parameter names

### DIFF
--- a/src/Repetier/src/io/io_heatManager.h
+++ b/src/Repetier/src/io/io_heatManager.h
@@ -30,7 +30,7 @@
     name.update();
 #define HEAT_MANAGER_PELTIER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable, pType, flowPin, minTemp) \
     name.update();
-#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, time1, up1, down1, time2, up2, down2, hotPlugable) \
+#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable) \
     name.update();
 
 #elif IO_TARGET == IO_TARGET_INIT // init
@@ -44,7 +44,7 @@
 #define HEAT_MANAGER_PELTIER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable, pType, flowPin, minTemp) \
     name.init();
 
-#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, time1, up1, down1, time2, up2, down2, hotPlugable) \
+#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable) \
     name.init();
 
 #define HEAT_MANAGER_DEFINE_HYSTERESIS(name, hysteresisTemperature, hysteresisTime, maxWait) \
@@ -58,7 +58,7 @@
     extern HeatManagerPID name;
 #define HEAT_MANAGER_PELTIER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable, pType, flowPin, minTemp) \
     extern HeatManagerPeltierPID<flowPin, pType, minTemp> name;
-#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, time1, up1, down1, time2, up2, down2, hotPlugable) \
+#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable) \
     extern HeatManagerDynDeadTime name;
 
 #elif IO_TARGET == IO_TARGET_DEFINE_VARIABLES
@@ -72,8 +72,8 @@
 #define HEAT_MANAGER_PELTIER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable, pType, flowPin, minTemp) \
     HeatManagerPeltierPID<flowPin, pType, minTemp> name(tp, index, &input, &output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable);
 
-#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, time1, up1, down1, time2, up2, down2, hotPlugable) \
-    HeatManagerDynDeadTime name(tp, index, &input, &output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, time1, up1, down1, time2, up2, down2, hotPlugable);
+#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable) \
+    HeatManagerDynDeadTime name(tp, index, &input, &output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable);
 
 #elif IO_TARGET == IO_TARGET_RESTORE_FROM_CONFIG // restore from config
 
@@ -83,8 +83,8 @@
     name.resetFromConfig(maxPwm, decVariance, decPeriod, p, i, d, driveMin, driveMax);
 #define HEAT_MANAGER_PELTIER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable, pType, flowPin, minTemp) \
     name.resetFromConfig(maxPwm, decVariance, decPeriod, p, i, d, driveMin, driveMax);
-#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, time1, up1, down1, time2, up2, down2, hotPlugable) \
-    name.resetFromConfig(maxPwm, decVariance, decPeriod, time1, up1, down1, time2, up2, down2);
+#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable) \
+    name.resetFromConfig(maxPwm, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2);
 #define HEAT_MANAGER_DEFINE_HYSTERESIS(name, hysteresisTemperature, hysteresisTime, maxWait) \
     name.initHysteresis(hysteresisTemperature, hysteresisTime, maxWait);
 
@@ -105,7 +105,7 @@
 #define HEAT_MANAGER_PELTIER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable, pType, flowPin, minTemp)
 #endif
 #ifndef HEAT_MANAGER_DYN_DEAD_TIME
-#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, sampleTime, maxPwm, decVariance, decPeriod, time1, up1, down1, time2, up2, down2, hotPlugable)
+#define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable)
 #endif
 
 #ifndef HEAT_MANAGER_DEFINE_HYSTERESIS


### PR DESCRIPTION
time1 corrected to temp1, up1 corrected to timeUp1, etc. 