### PR TITLE
PWM Kickstart - only from 0 & parameter names fix

### DIFF
--- a/src/Repetier/src/io/io_pwm.h
+++ b/src/Repetier/src/io/io_pwm.h
@@ -80,7 +80,7 @@
 
 #elif IO_TARGET == IO_TARGET_100MS // 100ms
 
-#define IO_PWM_KICKSTART(name, pwmname, timems, treshold) \
+#define IO_PWM_KICKSTART(name, pwmname, time100ms, treshold) \
     if (name.kickcount > 0) { \
         if (--name.kickcount == 0) { \
             pwmname.set(name.pwm); \
@@ -340,7 +340,7 @@
 #define IO_PWM_MIN_SPEED(name, pwmname, minValue, offBelow) \
     name##Class name;
 
-#define IO_PWM_KICKSTART(name, pwmname, timems, treshold) \
+#define IO_PWM_KICKSTART(name, pwmname, time100ms, treshold) \
     name##Class name;
 
 #define IO_PWM_RAMP(name, pwmname, upDelay100ms, downDelay100ms, difThreshold) \
@@ -376,7 +376,7 @@
 #define IO_PWM_MIN_SPEED(name, pwmname, minValue, offBelow)
 #endif
 #ifndef IO_PWM_KICKSTART
-#define IO_PWM_KICKSTART(name, pwmname, timems, treshold)
+#define IO_PWM_KICKSTART(name, pwmname, time100ms, treshold)
 #endif
 #ifndef IO_PWM_RAMP
 #define IO_PWM_RAMP(name, pwmname, upDelay100ms, downDelay100ms, difThreshold)

--- a/src/Repetier/src/io/io_pwm.h
+++ b/src/Repetier/src/io/io_pwm.h
@@ -237,7 +237,9 @@
             : pwm(0) \
             , kickcount(0) {} \
         void set(fast8_t _pwm) final { \
-            if (kickcount == 0 && _pwm < treshold && _pwm > pwm && time100ms > 0) { \
+            if (kickcount == 0 && _pwm < treshold \
+                && (pwm == 0 && _pwm > 0) \
+                && time100ms > 0) { \
                 pwm = _pwm; \
                 kickcount = time100ms; \
                 pwmname.set(255); \


### PR DESCRIPTION
karl_ranseier suggested that it might be better to just kickstart only from zero pwm.

Figure since the fans are already moving with some sort of inertia, they don't really need any more kickstarting afterwards, even if they're spinning slowly. 
Seems to work okay with all my fans so far. 

IO_PWM_KICKSTART's parameter names needed a slight fix on some macros.