### PR TITLE
Fix CSV Import step error & Fix homing step error

### DIFF
--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -772,9 +772,12 @@ void Leveling::importBumpMatrix(char* filename) {
     } else {
         Motion1::setAutolevelActive(true);
     }
-    Com::printArrayFLN(Com::tTransformationMatrix, Motion1::autolevelTransformation, 9, 6);
 
+    Motion1::waitForEndOfMoves();
     setDistortionEnabled(true);
+    Motion1::waitForEndOfMoves();
+
+    Com::printArrayFLN(Com::tTransformationMatrix, Motion1::autolevelTransformation, 9, 6);
     reportDistortionStatus();
 
     Com::printFLN(PSTR("Bump matrix succesfully imported."));

--- a/src/Repetier/src/motion/MotionLevel1.cpp
+++ b/src/Repetier/src/motion/MotionLevel1.cpp
@@ -1608,7 +1608,7 @@ void Motion1::homeAxes(fast8_t axes) {
 #endif
     // We measure in printer coordinates, so deactivate all corrections
     bool isAL = isAutolevelActive();
-    setAutolevelActive(false);
+    setAutolevelActive(false, true);
     bool bcActive = Leveling::isDistortionEnabled();
     Leveling::setDistortionEnabled(false);
     updatePositionsFromCurrent();
@@ -1678,7 +1678,7 @@ void Motion1::homeAxes(fast8_t axes) {
     }
     Printer::setHomedAll(ok);
     // Reactivate corrections
-    setAutolevelActive(isAL);
+    setAutolevelActive(isAL, true);
     Leveling::setDistortionEnabled(bcActive);
 
     if (axes & axisBits[Z_AXIS]) {


### PR DESCRIPTION
CSV matrix importing caused a slight step error once finished importing.

The autolevel disable/enable print messages were very rarely causing some step errors during homing as well, I silenced them just for homing. 