### PR TITLE
STM32 & Due IRQ Priorities adjustment/fixes

### DIFF
--- a/src/Repetier/src/boardFiles/skr_mini_e3_v1_2/variant.h
+++ b/src/Repetier/src/boardFiles/skr_mini_e3_v1_2/variant.h
@@ -88,6 +88,10 @@
 #define PIN_WIRE_SDA            PB7
 #define PIN_WIRE_SCL            PB6
 
+#ifndef EXTI_IRQ_PRIO
+#define EXTI_IRQ_PRIO 1 // Endstops
+#endif
+
 // Always have the TFT serial2 port defined for config.h changes and compiles. 
 #define HAL_USART_MODULE_ENABLED
 #define HAVE_HWSERIAL2

--- a/src/Repetier/src/boardFiles/skr_mini_e3_v2_0/variant.h
+++ b/src/Repetier/src/boardFiles/skr_mini_e3_v2_0/variant.h
@@ -88,6 +88,10 @@
 #define PIN_WIRE_SDA            PB7
 #define PIN_WIRE_SCL            PB6
 
+#ifndef EXTI_IRQ_PRIO
+#define EXTI_IRQ_PRIO 1 // Endstops
+#endif
+
 // Always have the TFT serial2 port defined for config.h changes and compiles. 
 #define HAL_USART_MODULE_ENABLED
 #define HAVE_HWSERIAL2

--- a/src/Repetier/src/boards/STM32F4/HAL.cpp
+++ b/src/Repetier/src/boards/STM32F4/HAL.cpp
@@ -310,6 +310,8 @@ void HAL::hwSetup(void) {
 
 // Set up all timer interrupts
 void HAL::setupTimer() {
+    /*!< 4 bits for pre-emption priority (0-15) 0 bits for subpriority */
+    HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
     motion2 = reserveTimerInterrupt(MOTION2_TIMER_NUM); // prevent pwm usage
     motion2->timer = new HardwareTimer(TIMER(MOTION2_TIMER_NUM));
     motion2->timer->setMode(2, TIMER_OUTPUT_COMPARE);
@@ -351,6 +353,7 @@ void HAL::setupTimer() {
             // Not on by default for output_compare
             LL_TIM_OC_EnablePreload(TIMER(TONE_TIMER_NUM), toneTimer->timer->getLLChannel(1));
             LL_TIM_OC_EnableFast(TIMER(TONE_TIMER_NUM), toneTimer->timer->getLLChannel(1));
+            toneTimer->timer->setInterruptPriority(1, 0);
             toneTimer->timer->refresh();
             toneTimer->timer->resume();
             break;

--- a/src/Repetier/src/boards/due/HAL.cpp
+++ b/src/Repetier/src/boards/due/HAL.cpp
@@ -89,7 +89,7 @@ void HAL::setupTimer() {
     // Timer for extruder control
     pmc_enable_periph_clk(MOTION2_TIMER_IRQ); // enable power to timer
     //NVIC_SetPriority((IRQn_Type)EXTRUDER_TIMER_IRQ, NVIC_EncodePriority(4, 4, 1));
-    NVIC_SetPriority((IRQn_Type)MOTION2_TIMER_IRQ, 15);
+    NVIC_SetPriority((IRQn_Type)MOTION2_TIMER_IRQ, 2);
 
     // count up to value in RC register using given clock
     TC_Configure(MOTION2_TIMER, MOTION2_TIMER_CHANNEL, TC_CMR_WAVSEL_UP_RC | TC_CMR_WAVE | TC_CMR_TCCLKS_TIMER_CLOCK1);
@@ -108,7 +108,7 @@ void HAL::setupTimer() {
     // Regular interrupts for heater control etc
     pmc_enable_periph_clk(PWM_TIMER_IRQ);
     //NVIC_SetPriority((IRQn_Type)PWM_TIMER_IRQ, NVIC_EncodePriority(4, 6, 0));
-    NVIC_SetPriority((IRQn_Type)PWM_TIMER_IRQ, 15);
+    NVIC_SetPriority((IRQn_Type)PWM_TIMER_IRQ, 6);
 
     TC_FindMckDivisor(PWM_CLOCK_FREQ, F_CPU_TRUE, &tc_count, &tc_clock, F_CPU_TRUE);
     TC_Configure(PWM_TIMER, PWM_TIMER_CHANNEL, TC_CMR_WAVSEL_UP_RC | TC_CMR_WAVE | tc_clock);
@@ -141,7 +141,7 @@ void HAL::setupTimer() {
 #if NUM_SERVOS > 0 || NUM_BEEPER > 0
     pmc_enable_periph_clk(SERVO_TIMER_IRQ);
     //NVIC_SetPriority((IRQn_Type)SERVO_TIMER_IRQ, NVIC_EncodePriority(4, 5, 0));
-    NVIC_SetPriority((IRQn_Type)SERVO_TIMER_IRQ, 4);
+    NVIC_SetPriority((IRQn_Type)SERVO_TIMER_IRQ, 3);
 
     TC_Configure(SERVO_TIMER, SERVO_TIMER_CHANNEL, TC_CMR_WAVSEL_UP_RC | TC_CMR_WAVE | TC_CMR_TCCLKS_TIMER_CLOCK1);
 
@@ -158,7 +158,7 @@ void HAL::setupTimer() {
             // If we have any SW beepers, enable the beeper IRQ
             pmc_set_writeprotect(false);
             pmc_enable_periph_clk((uint32_t)BEEPER_TIMER_IRQ);
-            NVIC_SetPriority((IRQn_Type)BEEPER_TIMER_IRQ, 25);
+            NVIC_SetPriority((IRQn_Type)BEEPER_TIMER_IRQ, 1);
 
             TC_Configure(BEEPER_TIMER, BEEPER_TIMER_CHANNEL, TC_CMR_WAVE | TC_CMR_WAVSEL_UP_RC | TC_CMR_TCCLKS_TIMER_CLOCK1);
 


### PR DESCRIPTION
- STM32's had their priority grouping set to 3 bits preempt, 1 bit sub priority. Adjusted them to 4 bits preempt, 0 sub since we're not using that feature & match Due. Shouldn't affect anything atm.

- E3 Mini's had their endstop interrupt priorities set to 6 by default. Adjusted to 1. 
- STM32F4 tone timer was missing it's setPriority, i'm not sure what it defaulted to. 

- I adjusted the Due's timer IRQ priorities to loosely match the other HAL's. They were quite low. I think I hear an extremely slight improvement in motion. (placebo?) 
- I set the STM32F1 set to the same priorities.


