### PR TITLE
Attachable/Detachable HW-Endstop interrupts when needed.

### DIFF
--- a/src/Repetier/src/io/io_endstop_definitions.h
+++ b/src/Repetier/src/io/io_endstop_definitions.h
@@ -44,8 +44,9 @@
 #define ENDSTOP_SWITCH(name, pin)
 
 #define ENDSTOP_SWITCH_HW(name, _pin, axis, dir) \
-    attachInterrupt((CPU_ARCH != ARCH_AVR) ? _pin::pin() : digitalPinToInterrupt(_pin::pin()), name##_cb, CHANGE); \
-    name.updateReal();
+    name.setCallback(name##_cb); \
+    name.setAttached(true); \
+    name.setAttached(ALWAYS_CHECK_ENDSTOPS);
 
 #define ENDSTOP_SWITCH_DEBOUNCE(name, pin, level)
 #define ENDSTOP_STEPPER(name)

--- a/src/Repetier/src/motion/MotionLevel1.h
+++ b/src/Repetier/src/motion/MotionLevel1.h
@@ -322,7 +322,8 @@ public:
     static bool simpleHome(fast8_t axis);
     static void correctBumpOffset(); // Adjust position to offset
     static PGM_P getAxisString(fast8_t axis);
-    static EndstopDriver& endstopFoxAxisDir(fast8_t axis, bool maxDir);
+    static EndstopDriver& endstopForAxisDir(fast8_t axis, bool maxDir);
+    static void setHardwareEndstopsAttached(bool attach, EndstopDriver* specificDriver = nullptr);
     static void resetTransformationMatrix(bool silent);
 #if LEVELING_METHOD > 0 || defined(DOXYGEN)
     //static void buildTransformationMatrix(float h1,float h2,float h3);


### PR DESCRIPTION
Smallish add-on to the endstop drivers. ( It should also work with merged endstops as well. ) and a function to Motion1 since it actually works well complimenting endstopForAxisDir. 

I've changed homing to attach the specific endstop we're going to use per axis. So far so good. 
ZProbe only attaches the ZProbe endstop at activate() and detaches at deactivate etc. 

Motion1::setHardwareEndstopsAttached(bool attach, EndstopDriver* specific = nullptr)
Attempts to detach/attach all axis HW endstops unless given a specific endstop driver to which to turn off.
Won't turn off any endstops if alwaysCheckEndstops is enabled. 

Hope I haven't missed anything with the other machine types though.