### PR TITLE
Fix SKR Mini - BTT TFT Simulation mode display

### DIFF
--- a/src/Repetier/src/u8g2/U8x8lib.cpp
+++ b/src/Repetier/src/u8g2/U8x8lib.cpp
@@ -45,10 +45,12 @@
 #include <Wire.h>
 #endif
 
+#if (FEATURE_CONTROLLER != CONTROLLER_NONE)
 #define UI_SPI_SCK UI_DISPLAY_D4_PIN
 #define UI_SPI_MOSI UI_DISPLAY_ENABLE_PIN
 #define UI_SPI_CS UI_DISPLAY_RS_PIN
 #define UI_SPI_DC UI_DISPLAY_D5_PIN
+#endif
 
 /*=============================================*/
 
@@ -463,7 +465,7 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t* u8x8, uint8_t msg, uin
     return 1;
 }
 
-#elif defined(__SAM3X8E__) || defined(STM32F1)
+#elif (defined(__SAM3X8E__) || defined(STM32F1)) && (FEATURE_CONTROLLER != CONTROLLER_NONE)
 inline void u8g2_spi_wait_short() {
     asm volatile("nop" ::); // 11.9ns
     asm volatile("nop" ::); // 11.9ns
@@ -571,7 +573,7 @@ extern "C" uint8_t u8x8_byte_arduino_4wire_sw_spi(u8x8_t* u8x8, uint8_t msg, uin
     constexpr ufast8_t filterShift = 8; // lowpass filter shift/average applied to overhead cycles
                                         // gathered between successive byte sends.
 
-    constexpr uint32_t clocksPerByte = 1600; // approx clock cycles for a byte + wait
+    constexpr uint32_t clocksPerByte = 1100; // approx clock cycles for a byte + wait
 
     constexpr ufast8_t itOvrheadMult = 16; // multiplier "strength" applied to our overhead cycles
                                            // before subtracting them from clocks per byte

--- a/src/Repetier/src/u8g2/u8x8_d_st7920.c
+++ b/src/Repetier/src/u8g2/u8x8_d_st7920.c
@@ -218,7 +218,11 @@ static const u8x8_display_info_t u8x8_st7920_128x64_display_info = {
     /* sck_pulse_width_ns = */ 140, /* datasheet ST7920 */
     /* sck_clock_hz = */ 100000UL,  /* since Arduino 1.6.0, the SPI bus speed in Hz. Should be  1000000000/sck_pulse_width_ns */
                                     /* ST7920+Due work with 1MHz but not with 2MHz, ST7920+Uno works with 2MHz */
+#if defined(STM32F1)
+    /* spi_mode = */ 3,             /* 11/3/20 - Changed SCK to active low for SKR mini's using BTT TFT's in simulator mode. */
+#else
     /* spi_mode = */ 1,             /* active high, rising edge, 18 Aug 16: changed from 1 to 3 which works for 101  */
+#endif
                                     /* in theory mode 3 should be correct  */
     /* i2c_bus_clock_100kHz = */ 4,
     /* data_setup_time_ns = */ 60,


### PR DESCRIPTION
Figured out why I couldn't get the little simulation mode to render. TFT appears to only accept an active low clock signal.
Changed the SPI mode only for STM32F1's inside u8g2's st7920 display info.  