### PR TITLE
Add SDCARD cap & fix BTT TFT -> onboard sdcard menu freeze.

### DIFF
--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -199,8 +199,9 @@ void __attribute__((weak)) MCode_25(GCode* com) {
 
 void __attribute__((weak)) MCode_26(GCode* com) {
 #if SDSUPPORT
-    if (com->hasS())
+    if (com->hasS()) {
         sd.setIndex(com->S);
+    }
 #endif
 }
 
@@ -212,8 +213,9 @@ void __attribute__((weak)) MCode_27(GCode* com) {
 
 void __attribute__((weak)) MCode_28(GCode* com) {
 #if SDSUPPORT
-    if (com->hasString())
+    if (com->hasString()) {
         sd.startWrite(com->text);
+    }
 #endif
 }
 
@@ -597,6 +599,11 @@ void __attribute__((weak)) MCode_115(GCode* com) {
     Com::cap(PSTR("PROGRESS:0"));
 #endif
     Com::cap(PSTR("AUTOREPORT_TEMP:1"));
+#if SDSUPPORT
+    Com::cap(PSTR("SDCARD:1"));
+#else
+    Com::cap(PSTR("SDCARD:0"));
+#endif
 #if ENABLED(HOST_RESCUE)
     Com::cap(PSTR("HOST_RESCUE:1"));
 #else

--- a/src/Repetier/src/sdcard/SDCard.cpp
+++ b/src/Repetier/src/sdcard/SDCard.cpp
@@ -53,10 +53,11 @@ void SDCard::automount() {
         }
     } else {
         if (!sdactive && sdmode != 100) {
-            UI_STATUS_UPD("SD Card inserted");
             mount();
-            if (sdmode != 100)                           // send message only if we have success
+            if (sdmode != 100) { // send message only if we have success
+                UI_STATUS_UPD("SD Card inserted");
                 Com::printFLN(PSTR("SD card inserted")); // Not translatable or host will not understand signal
+            }
 #if UI_DISPLAY_TYPE != NO_DISPLAY
             if (sdactive && !uid.isWizardActive()) { // Wizards have priority
                 Printer::setAutomount(true);
@@ -90,6 +91,7 @@ void SDCard::initsd() {
     if (!fat.begin(SDSS, SD_SCK_MHZ(constrain(SD_SPI_SPEED_MHZ, 1, 50)))) {
         Com::printFLN(Com::tSDInitFail);
         sdmode = 100; // prevent automount loop!
+        UI_STATUS_UPD("SD Card read error!");
         if (fat.card()->errorCode()) {
             Com::printFLN(PSTR(
                 "\nSD initialization failed.\n"
@@ -111,7 +113,7 @@ void SDCard::initsd() {
         }
         return;
     }
-    Com::printFLN(PSTR("Card successfully initialized."));
+    Com::printFLN(PSTR("SD card ok")); // Specific string needed for some hosts! 
     sdactive = true;
     Printer::setMenuMode(MENU_MODE_SD_MOUNTED, true);
     HAL::pingWatchdog();
@@ -237,10 +239,12 @@ void SDCard::continuePrint(bool intern) {
 }
 
 void SDCard::stopPrint() {
-    if (!sd.sdactive)
+    if (!sd.sdactive) {
         return;
-    if (sdmode)
+    }
+    if (sdmode) {
         Com::printFLN(PSTR("SD print stopped by user."));
+    }
     sdmode = 21;
     Printer::setMenuMode(MENU_MODE_SD_PRINTING, false);
     Printer::setMenuMode(MENU_MODE_PAUSED, false);


### PR DESCRIPTION
The BTT TFT Firmware was getting stuck waiting for a marlin response of "SD card ok" after attempting a M21 mount. 
I changed our previous print "Card successfully initialized." to it so the host doesn't lock up anymore. 

I added the SDCARD Cap if we have SDSUPPORT enabled. (Need to show the onboard SD menu option)

I also moved the SD card mounted UI_STATUS_UPD a bit in SDCard.cpp. It was still showing up as inserted even if we failed to read the sd.