### PR TITLE
Add AUTOREPORT_SD_STATUS cap & M27 C0 S<sec>P<millis> SD status Autoreports

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -62,8 +62,12 @@ int Printer::currentLayer = 0;
 int Printer::maxLayer = -1;       // -1 = unknown
 char Printer::printName[21] = ""; // max. 20 chars + 0
 float Printer::progress = 0;
+
 millis_t Printer::lastTempReport = 0;
-millis_t Printer::autoReportPeriodMS = 1000;
+millis_t Printer::autoTempReportPeriodMS = 1000;
+millis_t Printer::lastSDReport = 0;
+millis_t Printer::autoSDReportPeriodMS = 0;
+
 int32_t Printer::printingTime = 0;
 
 uint32_t Printer::interval = 30000;      ///< Last step duration in ticks.

--- a/src/Repetier/src/PrinterTypes/Printer.h
+++ b/src/Repetier/src/PrinterTypes/Printer.h
@@ -126,6 +126,7 @@ public:
 #define PRINTER_FLAG2_JAMCONTROL_DISABLED 32
 #define PRINTER_FLAG2_HOMING 64
 #define PRINTER_FLAG2_ALL_E_MOTORS 128 // Set all e motors flag
+#define PRINTER_FLAG3_AUTOREPORT_SD 4  // auto reports current file byte pos
 #define PRINTER_FLAG3_PRINTING 8       // set explicitly with M530
 #define PRINTER_FLAG3_AUTOREPORT_TEMP 16
 #define PRINTER_FLAG3_SUPPORTS_STARTSTOP 32
@@ -265,8 +266,10 @@ public:
     static uint32_t interval;            ///< Last step duration in ticks.
     static uint32_t timer;               ///< used for acceleration/deceleration timing
     static uint32_t stepNumber;          ///< Step number in current move.
-    static millis_t lastTempReport;      ///< Time of last temperature report for autoreport temperatures
-    static millis_t autoReportPeriodMS;  ///< Configurable delay between autoreports in ms. Default 1000ms.
+    static millis_t lastTempReport;      ///< Time of last temperature report for autoreporting temperatures
+    static millis_t autoTempReportPeriodMS;  ///< Configurable delay between autoreports in ms. Default 1000ms.
+    static millis_t lastSDReport;        ///< Time of last SD read position report for autoreporting SD position
+    static millis_t autoSDReportPeriodMS;///< Configurable delay between SD autoreports in ms. Default off. 
     static int32_t printingTime;         ///< Printing time in seconds
     static float extrudeMultiplyError;   ///< Accumulated error during extrusion
     static float extrusionFactor;        ///< Extrusion multiply factor
@@ -409,6 +412,14 @@ public:
 
     static INLINE void setAutoreportTemp(uint8_t b) {
         flag3 = (b ? flag3 | PRINTER_FLAG3_AUTOREPORT_TEMP : flag3 & ~PRINTER_FLAG3_AUTOREPORT_TEMP);
+    }
+
+    static INLINE uint8_t isAutoreportSD() {
+        return flag3 & PRINTER_FLAG3_AUTOREPORT_SD;
+    }
+
+    static INLINE void setAutoreportSD(uint8_t b) {
+        flag3 = (b ? flag3 | PRINTER_FLAG3_AUTOREPORT_SD : flag3 & ~PRINTER_FLAG3_AUTOREPORT_SD);
     }
 
     static INLINE uint8_t isAllKilled() {

--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -551,7 +551,7 @@ public:
         sdpos = newpos;
         file.seekSet(sdpos);
     }
-    void printStatus();
+    void printStatus(bool getFilename = false);
     void ls();
 #if JSON_OUTPUT
     void lsJSON(const char* filename);

--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -123,12 +123,21 @@ void Commands::checkForPeriodicalActions(bool allowNewMoves) {
     // Report temperatures every autoReportPeriodMS (default 1000ms), so we do not need to send M105
     if (Printer::isAutoreportTemp()) {
         millis_t now = HAL::timeInMilliseconds();
-        if (now - Printer::lastTempReport > Printer::autoReportPeriodMS) {
+        if (now - Printer::lastTempReport > Printer::autoTempReportPeriodMS) {
             Printer::lastTempReport = now;
             Commands::printTemperatures();
         }
     }
-
+#if SDSUPPORT
+    // Reports the sd file byte position every autoSDReportPeriodMS if set, and only if printing. 
+    if (Printer::isAutoreportSD() && sd.sdactive && (sd.sdmode == 1 || sd.sdmode == 2)) {
+        millis_t now = HAL::timeInMilliseconds();
+        if (now - Printer::lastSDReport > Printer::autoSDReportPeriodMS) {
+            Printer::lastSDReport = now;
+            sd.printStatus();
+        }
+    }
+#endif
     EVENT_TIMER_100MS;
     // Extruder::manageTemperatures();
     if (--counter500ms == 0) {

--- a/src/Repetier/src/communication/Communication.cpp
+++ b/src/Repetier/src/communication/Communication.cpp
@@ -416,6 +416,7 @@ FSTRINGVALUE(Com::tFileSelected, "File selected")
 FSTRINGVALUE(Com::tFileOpenFailed, "file.open failed")
 FSTRINGVALUE(Com::tSDPrintingByte, "SD printing byte ")
 FSTRINGVALUE(Com::tNotSDPrinting, "Not SD printing")
+FSTRINGVALUE(Com::tCurrentOpenFile, "Current file: ") // Compat with hosts that use M27 C
 FSTRINGVALUE(Com::tOpenFailedFile, "open failed, File: ")
 FSTRINGVALUE(Com::tWritingToFile, "Writing to file: ")
 FSTRINGVALUE(Com::tDoneSavingFile, "Done saving file.")
@@ -591,8 +592,9 @@ void Com::printFLN(FSTRINGPARAM(text), const char* msg) {
 
 void Com::printF(FSTRINGPARAM(ptr)) {
     char c;
-    while ((c = HAL::readFlashByte(ptr++)) != 0)
+    while ((c = HAL::readFlashByte(ptr++)) != 0) {
         GCodeSource::writeToAll(c);
+    }
 }
 
 void Com::printF(FSTRINGPARAM(text), const char* msg) {

--- a/src/Repetier/src/communication/Communication.h
+++ b/src/Repetier/src/communication/Communication.h
@@ -448,6 +448,7 @@ public:
     FSTRINGVAR(tFileOpenFailed)
     FSTRINGVAR(tSDPrintingByte)
     FSTRINGVAR(tNotSDPrinting)
+    FSTRINGVAR(tCurrentOpenFile)
     FSTRINGVAR(tOpenFailedFile)
     FSTRINGVAR(tWritingToFile)
     FSTRINGVAR(tDoneSavingFile)

--- a/src/Repetier/src/main.cpp
+++ b/src/Repetier/src/main.cpp
@@ -91,8 +91,9 @@ Custom M Codes
 - M23  - Select SD file (M23 filename.g)
 - M24  - Start/resume SD print
 - M25  - Pause SD print
-- M26  - Set SD position in bytes (M26 S12345)
-- M27  - Report SD print status
+- M26  - Set SD position in bytes (M26 S12345) 
+- M27 C0 S<seconds/off> P<milliseconds/off> - Report SD print status. 
+        Set S<sec> P<ms> to enable autoreporting while printing, set P or S to 0 to disable. Set C without P or S to report the current open filename.
 - M28  - Start SD write (M28 filename.g)
 - M29  - Stop SD write
 - M30 <filename> - Delete file on sd card
@@ -120,7 +121,8 @@ Custom M Codes
 - M118 <message> - Write message to host
 - M119 - Report endstop status
 - M140 S<temp> H1 O<offset> F1 - Set bed target temp, F1 makes a beep when temperature is reached the first time
-- M155 S<1/0> P<milliseconds> Enable/disable auto report temperatures. When enabled firmware will emit temperatures every second by default. Set P<ms> to change the autoreport frequency (100ms - 10s), resets to 1000ms if P is omitted.
+- M155 S<seconds/off> P<milliseconds/off> - Enable/disable autoreport temperatures. 
+        Temperatures reported every second by default. Set S<sec> P<ms> to change the frequency (100ms - 60s), resets to 1000ms if P and S are omitted. Set P or S to 0 to disable autoreporting.
 - M163 S<extruderNum> P<weight>  - Set weight for this mixing extruder drive
 - M164 S<virtNum> P<0 = dont store eeprom,1 = store to eeprom> - Store weights as virtual extruder S
 - M170 B<bedtemp> T<extruderid> S<extrudertemp> L0 - Set preset temperatures for extruder (T+S) or bed (B) or list settings (L0)

--- a/src/Repetier/src/sdcard/SDCard.cpp
+++ b/src/Repetier/src/sdcard/SDCard.cpp
@@ -113,7 +113,7 @@ void SDCard::initsd() {
         }
         return;
     }
-    Com::printFLN(PSTR("SD card ok")); // Specific string needed for some hosts! 
+    Com::printFLN(PSTR("SD card ok")); // Specific string needed for some hosts!
     sdactive = true;
     Printer::setMenuMode(MENU_MODE_SD_MOUNTED, true);
     HAL::pingWatchdog();
@@ -617,12 +617,21 @@ bool SDCard::selectFile(const char* filename, bool silent) {
     }
 }
 
-void SDCard::printStatus() {
-    if (sdactive) {
-        Com::printF(Com::tSDPrintingByte, sdpos);
-        Com::printFLN(Com::tSlash, filesize);
+void SDCard::printStatus(bool getFilename) {
+    if (getFilename) {
+        Com::printF(Com::tCurrentOpenFile);
+        if (sdactive && file.getName(tempLongFilename, sizeof(tempLongFilename))) {
+            Com::printFLN(tempLongFilename);
+        } else {
+            Com::printFLN(PSTR("(no file)"));
+        }
     } else {
-        Com::printFLN(Com::tNotSDPrinting);
+        if (sdactive && (sdmode == 1 || sdmode == 2)) {
+            Com::printF(Com::tSDPrintingByte, sdpos);
+            Com::printFLN(Com::tSlash, filesize);
+        } else {
+            Com::printFLN(Com::tNotSDPrinting);
+        }
     }
 }
 


### PR DESCRIPTION
Just a quick clone of autoreport temperatures. Only autoreports byte positions during a SD print. Requires SDSUPPORT. 

I've brought in the S<seconds> parameter to M27 and M155 as well for better compatibility across hosts. 

Setting either P or S to 0 will disable autoreporting. Using both will just combine them.

Omitting P _and_ S for M27 will just print out the status as normal. Adding a C parameter will also print out the filename.