### PR TITLE
Due - Fix Freeze/Hang on USB disconnects.

### DIFF
--- a/src/Repetier/src/communication/gcode.cpp
+++ b/src/Repetier/src/communication/gcode.cpp
@@ -1238,6 +1238,14 @@ int SerialGCodeSource::readByte() {
 #endif
 }
 void SerialGCodeSource::writeByte(uint8_t byte) {
+#if defined(DUE_BOARD)
+    if (usbHostSource == this) {
+        if (!Is_udd_suspend()) {
+            stream->write(byte);
+        }
+        return;
+    }
+#endif
     stream->write(byte);
 }
 void SerialGCodeSource::close() {


### PR DESCRIPTION
Fixes a really old problem with the native ports on Arduino Due's and the Arduino Library. 
Disconnecting the native port and then trying to serial write will cause an infinite loop. 

This works around the issue by checking if the USB port is in a suspend state before trying to write bytes.

Learned about using the suspend state from STM32. Used to check if they're connected or not in their HAL. 

(I think OS's have the choice to implement/broadcast suspend functionality or not, but so far it reliably changes state from my Pi and Windows desktop)