### PR TITLE
Fix extruder temp disable button

### DIFF
--- a/src/Repetier/src/drivers/heatManager.cpp
+++ b/src/Repetier/src/drivers/heatManager.cpp
@@ -20,7 +20,11 @@ void menuDisableTemperature(GUIAction action, void* data) {
 #if FEATURE_CONTROLLER != NO_CONTROLLER
     HeatManager* hm = reinterpret_cast<HeatManager*>(data);
     hm->setTargetTemperature(hm->getMinTemperature());
+    // Now remove the Disable button & move the display up if needed.
     GUI::cursorRow[GUI::level]--;
+    if (GUI::topRow[GUI::level]) {
+        GUI::topRow[GUI::level]--;
+    }
 #endif
 }
 


### PR DESCRIPTION
Found the button wasn't properly reducing the row count/updating the extruder menu on 20x4's without back buttons.