### PR TITLE
Implements M575 - Change Serial baudrate

### DIFF
--- a/src/Repetier/src/communication/Commands.cpp
+++ b/src/Repetier/src/communication/Commands.cpp
@@ -504,7 +504,7 @@ void Commands::processMCode(GCode* com) {
     case 84: // M84
         MCode_84(com);
         break;
-    case 85: // M85
+    case 85: // M85 S<seconds> - Set an inactivity shutdown timer. (maxInactiveTime)
         MCode_85(com);
         break;
     case 92: // M92
@@ -733,6 +733,9 @@ void Commands::processMCode(GCode* com) {
         break;
     case 569: // Set stealthchop
         MCode_Stepper(com);
+        break;
+    case 575: // Update all serial baudrates 
+        MCode_575(com);
         break;
     case 600:
         MCode_600(com);

--- a/src/Repetier/src/communication/Commands.h
+++ b/src/Repetier/src/communication/Commands.h
@@ -177,6 +177,7 @@ void MCode_531(GCode* com);
 void MCode_532(GCode* com);
 void MCode_539(GCode* com);
 void MCode_540(GCode* com);
+void MCode_575(GCode* com);
 void MCode_576(GCode* com);
 void MCode_600(GCode* com);
 void MCode_601(GCode* com);

--- a/src/Repetier/src/communication/GCodes.cpp
+++ b/src/Repetier/src/communication/GCodes.cpp
@@ -153,7 +153,7 @@ void __attribute__((weak)) GCode_2_3(GCode* com) {
         HeatManager* heater = Tool::getActiveTool()->getHeater();
         if (Printer::relativeCoordinateMode || Printer::relativeExtruderCoordinateMode) {
             if (fabs(com->E) * Printer::extrusionFactor > EXTRUDE_MAXLENGTH) {
-                Com::printWarningF(PSTR("MAx. extrusion distance per move exceeded - ignoring move."));
+                Com::printWarningF(PSTR("Max. extrusion distance per move exceeded - ignoring move."));
                 p = 0;
             }
             target[E_AXIS] = Motion1::currentPosition[E_AXIS] + p;
@@ -287,10 +287,11 @@ void __attribute__((weak)) GCode_4(GCode* com) {
     int32_t codenum;
     Motion1::waitForEndOfMoves();
     codenum = 0;
-    if (com->hasP())
-        codenum = com->P; // milliseconds to wait
-    if (com->hasS())
+    if (com->hasS()) {
         codenum = com->S * 1000; // seconds to wait
+    } else if (com->hasP()) {
+        codenum = com->P; // milliseconds to wait
+    }
 
     codenum += HAL::timeInMilliseconds(); // keep track of when we started waiting
     while ((uint32_t)(codenum - HAL::timeInMilliseconds()) < 2000000000) {

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -373,10 +373,7 @@ void __attribute__((weak)) MCode_84(GCode* com) {
 }
 
 void __attribute__((weak)) MCode_85(GCode* com) {
-    if (com->hasS())
-        maxInactiveTime = (int32_t)com->S * 1000;
-    else
-        maxInactiveTime = 0;
+    maxInactiveTime = static_cast<millis_t>(com->getS(0l) * 1000l);
 }
 
 void __attribute__((weak)) MCode_92(GCode* com) {
@@ -1438,6 +1435,20 @@ void __attribute__((weak)) MCode_540(GCode* com) {
     Motion1::reportBuffers();
     Motion2::reportBuffers();
     Motion3::reportBuffers();
+}
+
+void __attribute__((weak)) MCode_575(GCode* com) {
+    if (!Printer::isNativeUSB() && com->hasB() && static_cast<int32_t>(com->B) > 0l) {
+        int32_t curBaud = 0l;
+        for (size_t i = 0ul; (curBaud = pgm_read_dword(&(baudrates[i]))); i++) {
+            if (static_cast<int32_t>(com->B) == curBaud) {
+                HAL::serialFlush();
+                HAL::serialSetBaudrate((baudrate = curBaud));
+                return;
+            }
+        }
+        Com::printFLN(PSTR("Invalid baudrate"));
+    }
 }
 
 // M576 S1 enables out of order execution

--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -4,6 +4,10 @@ const char* const axisNames[] PROGMEM = {
     "X", "Y", "Z", "E", "A", "B", "C"
 };
 
+const int32_t baudrates[] PROGMEM = {
+    38400, 56000, 57600, 76800, 115200, 128000, 230400, 250000, 256000, 460800, 500000, 0
+};
+
 void __attribute__((weak)) menuBabystepZ(GUIAction action, void* data) {
     DRAW_FLOAT_P(PSTR("Babystep Z:"), Com::tUnitMM, Motion1::totalBabystepZ, 2);
     if (GUI::handleFloatValueAction(action, v, 0.01f)) {
@@ -366,9 +370,6 @@ void __attribute__((weak)) menuControlProbe(GUIAction action, void* data) {
     GUI::menuEnd(action);
 #endif
 }
-
-const long baudrates[] PROGMEM = { 38400, 56000, 57600, 76800, 115200, 128000, 230400, 250000, 256000,
-                                   460800, 500000, 0 };
 
 void __attribute__((weak)) menuBaudrate(GUIAction action, void* data) {
     int32_t v = baudrate;

--- a/src/Repetier/src/controller/menu.h
+++ b/src/Repetier/src/controller/menu.h
@@ -3,6 +3,7 @@
 
 enum class GUIAction;
 extern const char* const axisNames[] PROGMEM;
+extern const int32_t baudrates[] PROGMEM;
 
 extern void menuMove(GUIAction action, void* data);
 extern void menuHome(GUIAction action, void* data);

--- a/src/Repetier/src/main.cpp
+++ b/src/Repetier/src/main.cpp
@@ -106,7 +106,7 @@ Custom M Codes
 - M83  - Set E codes relative while in Absolute Coordinates (G90) mode
 - M84  - Disable steppers until next move,
         or use S<seconds> to specify an inactivity timeout, after which the steppers will be disabled.  S0 to disable the timeout.
-- M85  - Set inactivity shutdown timer with parameter S<seconds>. To disable set zero (default)
+- M85 S<seconds> - Set an inactivity shutdown timer. To disable set 0. Default is MAX_INACTIVE_TIME.
 - M92  - Set axisStepsPerMM - same syntax as G92
 - M99 S<delayInSec> X0 Y0 Z0 - Disable motors for S seconds (default 10) for given axis.
 - M104 S<temp> T<extruder> P1 F1 H1 O<offset>- Set temperature without wait. P1 = wait for moves to finish, F1 = beep when temp. reached first time
@@ -181,6 +181,7 @@ Custom M Codes
 - M531 filename - Define filename being printed
 - M532 X<percent> L<curLayer> - update current print state progress (X=0..100) and layer L
 - M539 S<supportStartStop> P<paused> - S1 Tells firmware that host will use the feature. P1/0 signals paused/running state.
+- M575 B<Baudrate> - Update all available serial port baudrates to one of the permitted rates (38400, 56000, 57600, 76800, 115200, 128000, 230400, 250000, 256000, 460800, 500000)
 - M600 Change filament
 - M601 S<1/0> B<1/0> P<1/0> - Pause extruders. B1 also pauses heated bed. Paused extrudes disable heaters and motor. Continue (S0) reheats extruder to old temp. P0 does not wait for target temperature.
 - M602 S<1/0> P<1/0>- Debug jam control (S) Disable jam control (P). If enabled it will log signal changes and will not trigger jam errors!


### PR DESCRIPTION
Added M575 to change baudrates. Matches the other firmwares and our menu option. M575 B<baudrate>
Only 38400, 56000, 57600, 76800, 115200, 128000, 230400, 250000, 256000, 460800, 500000 are accepted.
Can't change per serial yet.

