### PR TITLE
Move SAM/AVR to C++14

### DIFF
--- a/src/Repetier/platformio.ini
+++ b/src/Repetier/platformio.ini
@@ -34,6 +34,10 @@ default_src_filter = +<*> -<boards> -<boardFiles>
 build_flags = -fmax-errors=5
   -g
   -ggdb
+  -std=gnu++14
+build_unflags =
+  -std=gnu++11
+  -std=c++11
 
 ; Properties shared with all envs if not overridden
 [env]
@@ -47,6 +51,7 @@ src_filter = ${common.default_src_filter} +<boards/due>
 debug_tool = jlink
 monitor_speed = 115200
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 
 [env:dueUSB]
 platform = atmelsam
@@ -56,6 +61,7 @@ src_filter = ${common.default_src_filter} +<boards/due>
 debug_tool = jlink
 monitor_speed = 115200
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 
 ; upload_protocol = jlink-jtag
 ; any port that starts with /dev/ttyUSB
@@ -69,6 +75,7 @@ board = megaatmega2560
 framework = arduino
 src_filter = ${common.default_src_filter} +<boards/avr>
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 
 [env:adafruit_grandcentral_m4]
 platform = atmelsam
@@ -79,6 +86,7 @@ framework = arduino
 monitor_speed = 115200
 debug_tool = jlink
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 
 [env:stacker_3d_superboard]
 platform = atmelsam
@@ -88,6 +96,7 @@ board_build.variants_dir = src/boardFiles/due
 src_filter = ${common.default_src_filter} +<boards/due>
 monitor_speed = 115200
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 
 [skr_mini_e3_base] # Base SKR E3 mini options/flags shared with v1.2 and v2.0 
 platform                    = ststm32@8.0.0


### PR DESCRIPTION
I saw STM32's use 14' by default but the SAM's and AVR don't. 
This should make them equal and gives us a few nifty things like constexpr functions with if's/variables, auto return types etc. 