### PR TITLE
HW IO_Endstop - Lambda callbacks

### DIFF
--- a/src/Repetier/src/drivers/endstops.cpp
+++ b/src/Repetier/src/drivers/endstops.cpp
@@ -33,6 +33,28 @@ inline bool EndstopSwitchDriver<inp>::update() {
 }
 
 template <class inp, int axis, bool dir>
+EndstopSwitchHardwareDriver<inp, axis, dir>::EndstopSwitchHardwareDriver(void_fn_t cb)
+    : state(false)
+    , parent(nullptr)
+    , callbackFunc(cb)
+    , attachPin((CPU_ARCH != ARCH_AVR) ? inp::pin() : digitalPinToInterrupt(inp::pin()))
+    , attached(false) {
+    setAttached(true);
+    setAttached(ALWAYS_CHECK_ENDSTOPS);
+}
+
+template <class inp, int axis, bool dir>
+void EndstopSwitchHardwareDriver<inp, axis, dir>::setAttached(bool attach) {
+    if (attach && !attached) {
+        attachInterrupt(attachPin, callbackFunc, CHANGE);
+        updateReal();
+    } else if (!attach && attached) {
+        detachInterrupt(attachPin);
+    }
+    attached = attach;
+}
+
+template <class inp, int axis, bool dir>
 inline void EndstopSwitchHardwareDriver<inp, axis, dir>::updateReal() {
     fast8_t newState = inp::get();
     if (state != newState) {

--- a/src/Repetier/src/io/io_endstop_definitions.h
+++ b/src/Repetier/src/io/io_endstop_definitions.h
@@ -29,40 +29,19 @@
 
 #define ENDSTOP_NONE(name) extern EndstopNoneDriver name;
 #define ENDSTOP_SWITCH(name, pin) extern EndstopSwitchDriver<pin> name;
-#define ENDSTOP_SWITCH_HW(name, pin, axis, dir) \
-    extern EndstopSwitchHardwareDriver<pin, axis, dir> name; \
-    extern void name##_cb();
+#define ENDSTOP_SWITCH_HW(name, pin, axis, dir) extern EndstopSwitchHardwareDriver<pin, axis, dir> name;
 #define ENDSTOP_SWITCH_DEBOUNCE(name, pin, level) extern EndstopSwitchDebounceDriver<pin, level> name;
 #define ENDSTOP_STEPPER(name) extern EndstopStepperControlledDriver name;
 #define ENDSTOP_MERGE2(name, e1, e2, axis, dir) extern EndstopMerge2 name;
 #define ENDSTOP_MERGE3(name, e1, e2, e3, axis, dir) extern EndstopMerge3 name;
 #define ENDSTOP_MERGE4(name, e1, e2, e3, e4, axis, dir) extern EndstopMerge4 name;
 
-#elif IO_TARGET == IO_TARGET_INIT // Init
-
-#define ENDSTOP_NONE(name)
-#define ENDSTOP_SWITCH(name, pin)
-
-#define ENDSTOP_SWITCH_HW(name, _pin, axis, dir) \
-    name.setCallback(name##_cb); \
-    name.setAttached(true); \
-    name.setAttached(ALWAYS_CHECK_ENDSTOPS);
-
-#define ENDSTOP_SWITCH_DEBOUNCE(name, pin, level)
-#define ENDSTOP_STEPPER(name)
-#define ENDSTOP_MERGE2(name, e1, e2, axis, dir)
-#define ENDSTOP_MERGE3(name, e1, e2, e3, axis, dir)
-#define ENDSTOP_MERGE4(name, e1, e2, e3, e4, axis, dir)
-
 #elif IO_TARGET == IO_TARGET_DEFINE_VARIABLES
 
 #define ENDSTOP_NONE(name) EndstopNoneDriver name;
 #define ENDSTOP_SWITCH(name, pin) EndstopSwitchDriver<pin> name;
 #define ENDSTOP_SWITCH_HW(name, pin, axis, dir) \
-    EndstopSwitchHardwareDriver<pin, axis, dir> name; \
-    void name##_cb() { \
-        name.updateReal(); \
-    }
+    EndstopSwitchHardwareDriver<pin, axis, dir> name([] { name.updateReal(); });
 #define ENDSTOP_SWITCH_DEBOUNCE(name, pin, level) EndstopSwitchDebounceDriver<pin, level> name;
 #define ENDSTOP_STEPPER(name) EndstopStepperControlledDriver name;
 #define ENDSTOP_MERGE2(name, e1, e2, axis, dir) EndstopMerge2 name(&e1, &e2, axis, dir);

--- a/src/Repetier/src/utilities/constants.h
+++ b/src/Repetier/src/utilities/constants.h
@@ -182,3 +182,4 @@
 #define XSTR(s) STR(s)
 
 typedef unsigned int uint;
+typedef void (*void_fn_t)();


### PR DESCRIPTION
Small update to HW endstop switches, now uses a lambda as a callback passed through the constructor. Slims the structure a bit. Removed IO_TARGET_INIT as it's no longer required. 

I created a new global typedef; void_fn_t, in constants.h. Easier use of simple functors in the future. 