### PR TITLE
SDCard - Fix manual unmount remount & pop menus.

### DIFF
--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -561,6 +561,9 @@ public:
     bool sdactive;
     //int16_t n;
     bool savetosd;
+    bool userUnmountDebounce;
+    bool lastReadState;
+    
     SdBaseFile parentFound;
 
     SDCard();
@@ -568,7 +571,7 @@ public:
     void writeCommand(GCode* code);
     bool selectFile(const char* filename, bool silent = false);
     void mount();
-    void unmount();
+    void unmount(bool manual);
     void startPrint();
     void pausePrint(bool intern = false);
     void pausePrintPart2();

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -172,7 +172,7 @@ void __attribute__((weak)) MCode_21(GCode* com) {
 
 void __attribute__((weak)) MCode_22(GCode* com) {
 #if SDSUPPORT
-    sd.unmount();
+    sd.unmount(true);
 #endif
 }
 

--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -738,6 +738,11 @@ static struct menuSDCacheStruct {
 
 void __attribute__((weak)) menuSDPrint(GUIAction action, void* data) {
     GUI::menuStart(action);
+    if (!sd.sdactive) { // User was still inside the menu when their sdcard ejected.
+        GUI::pop(); 
+        GUI::refresh(); 
+        return;
+    }
 
     if (GUI::folderLevel > 0) {
         GUI::menuText(action, GUI::cwd, true);


### PR DESCRIPTION
Fixes manually unmounting the SDCard via M22. It would immediately remount itself. 
Menus now clear if they were still open, and the working directory now correctly resets.