### PR TITLE
Feature - ZProbe Progress Screen

### DIFF
--- a/src/Repetier/src/communication/Communication.cpp
+++ b/src/Repetier/src/communication/Communication.cpp
@@ -277,6 +277,7 @@ FSTRINGVALUE(Com::tDBGDeltaVirtualAxisSteps, "Virtual axis steps:")
 #ifdef DEBUG_STEPCOUNT
 FSTRINGVALUE(Com::tDBGMissedSteps, "Missed steps:")
 #endif // DEBUG_STEPCOUNT
+FSTRINGVALUE(Com::tProbing, "Probing")
 FSTRINGVALUE(Com::tZProbe, "Z-probe:")
 FSTRINGVALUE(Com::tZProbeAverage, "Z-probe average height:")
 FSTRINGVALUE(Com::tZProbeZReset, "Reset Z height")

--- a/src/Repetier/src/communication/Communication.h
+++ b/src/Repetier/src/communication/Communication.h
@@ -324,6 +324,7 @@ public:
 #ifdef DEBUG_STEPCOUNT
     FSTRINGVAR(tDBGMissedSteps)
 #endif
+    FSTRINGVAR(tProbing)
     FSTRINGVAR(tZProbe)
     FSTRINGVAR(tZProbeStartScript)
     FSTRINGVAR(tZProbeEndScript)

--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -1379,73 +1379,64 @@ void __attribute__((weak)) printProgress(GUIAction action, void* data) {
 }
 
 void __attribute__((weak)) probeProgress(GUIAction action, void* data) {
-    if (action == GUIAction::DRAW) { 
-        GUI::bufClear();
-        GUI::bufAddStringP(PSTR("Probing"));
-        // Using our own counter instead of refresh_counter 
-        // since this screen might get updated faster than usual 
-        static ufast8_t dotCounter = 0;
-        static millis_t lastDotTime = 0;
-        if(HAL::timeInMilliseconds() - lastDotTime >= 1000) {
-            dotCounter++;
-            lastDotTime = HAL::timeInMilliseconds();
-        }
-
-        //...  
-        fast8_t len = dotCounter % 4; 
-        for (fast8_t i = 0; i < 3; i++) {
-            GUI::bufAddChar(i < len ? '.' : ' ');
-        } 
-
-        if (data != nullptr) {
-            struct pack {
-                float pointHeight;
-                ufast8_t posX;
-                ufast8_t posY;
-                ufast8_t pointNum;
-            };
-            pack* probeData = reinterpret_cast<pack*>(data);
-            GUI::bufAddChar(' ');
-            GUI::bufAddChar(' ');
-            GUI::bufAddChar(' ');
-            
-            GUI::bufAddChar(' ');
-            GUI::bufAddChar(' ');
-            GUI::bufAddChar(' ');
- 
-            GUI::bufAddLong((probeData->pointNum * 100) / (GRID_SIZE * GRID_SIZE), 3);
-            GUI::bufAddChar('%');
-            printRow(0, GUI::buf);
+    if (action == GUIAction::DRAW) {
+        if (Printer::isZProbingActive()) {
             GUI::bufClear();
-            // Xmm x Ymm
-            GUI::bufAddStringP(Com::tXColon);
-            GUI::bufAddLong(probeData->posX, 3);
-            GUI::bufAddStringP(Com::tUnitMM);
-            GUI::bufAddChar(' ');
-            GUI::bufAddStringP(Com::tYColon);
-            GUI::bufAddLong(probeData->posY, 3);
-            GUI::bufAddStringP(Com::tUnitMM);
-            printRowCentered(1, GUI::buf);
-            GUI::bufClear();
-            // (+0.000mm)
-            if (probeData->pointHeight != IGNORE_COORDINATE) {
-                GUI::bufAddChar('(');
-                if(probeData->pointHeight >= 0) {
-                    GUI::bufAddChar('+');
-                }   
-                GUI::bufAddFloat(probeData->pointHeight, 0, 3);
-                GUI::bufAddStringP(Com::tUnitMM);
-                GUI::bufAddChar(')');
+            GUI::bufAddStringP(Com::tProbing);
+            // Using our own counter instead of refresh_counter
+            // since this screen might get updated faster than usual
+            static ufast8_t dotCounter = 0;
+            static millis_t lastDotTime = 0;
+            if ((HAL::timeInMilliseconds() - lastDotTime) >= 1000ul) {
+                dotCounter++;
+                lastDotTime = HAL::timeInMilliseconds();
             }
-            printRowCentered(2, GUI::buf); 
-        } else { 
-            printRow(0, GUI::buf);
-            printRow(1, GUI::buf);
-            printRow(2, GUI::buf);
-        } 
-        printRow(3, GUI::status);
+
+            //...
+            fast8_t len = dotCounter % 4;
+            for (fast8_t i = 0; i < 3; i++) {
+                GUI::bufAddChar(i < len ? '.' : ' ');
+            }
+            if (data != nullptr) {
+                probeProgInfo* progInfo = static_cast<probeProgInfo*>(data);
+
+                GUI::bufAddChar(' ');
+                GUI::bufAddChar(' ');
+                GUI::bufAddLong((progInfo->num * 100u) / (progInfo->maxNum), 3);
+                GUI::bufAddChar('%');
+                printRow(0, GUI::buf);
+                GUI::bufClear();
+                // Xmm x Ymm
+                GUI::bufAddStringP(Com::tXColon);
+                GUI::bufAddLong(progInfo->x, 3);
+                GUI::bufAddStringP(Com::tUnitMM);
+                GUI::bufAddChar(' ');
+                GUI::bufAddStringP(Com::tYColon);
+                GUI::bufAddLong(progInfo->y, 3);
+                GUI::bufAddStringP(Com::tUnitMM);
+                printRowCentered(1, GUI::buf);
+                GUI::bufClear();
+                // (+0.000mm)
+                float z = progInfo->z;
+                if (z != IGNORE_COORDINATE && z != ILLEGAL_Z_PROBE) {
+                    GUI::bufAddChar('(');
+                    if (z >= 0) {
+                        GUI::bufAddChar('+');
+                    }
+                    GUI::bufAddFloat(z, 0, 3);
+                    GUI::bufAddStringP(Com::tUnitMM);
+                    GUI::bufAddChar(')');
+                }
+                printRowCentered(2, GUI::buf);
+            } else {
+                GUI::bufClear();
+                printRow(0, GUI::buf);
+                printRow(1, GUI::buf);
+                printRow(2, GUI::buf);
+            }
+            printRow(3, GUI::status);
+        }
     }
-    // Can't return back to this menu atm.
     GUI::replaceOn(GUIAction::NEXT, startScreen, nullptr, GUIPageType::FIXED_CONTENT);
     GUI::replaceOn(GUIAction::PREVIOUS, startScreen, nullptr, GUIPageType::FIXED_CONTENT);
     GUI::pushOn(GUIAction::CLICK, mainMenu, nullptr, GUIPageType::MENU);

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -52,7 +52,7 @@ void __attribute__((weak)) errorScreenP(GUIAction action, void* data) { }
 #if DISPLAY_DRIVER != DRIVER_NONE
 void GUI::resetMenu() { ///< Go to start page
     level = 0;
-    replace(Printer::isPrinting() ? printProgress : startScreen, nullptr, GUIPageType::TOPLEVEL);
+    replace(Printer::isPrinting() ? printProgress : Printer::isZProbingActive() ? probeProgress : startScreen, nullptr, GUIPageType::TOPLEVEL);
 }
 #endif
 

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -20,6 +20,7 @@ char GUI::tmpString[MAX_COLS + 1];           ///< Buffer to build strings
 fast8_t GUI::bufPos;                         ///< Pos for appending data
 GUIBootState GUI::curBootState = GUIBootState::DISPLAY_INIT;
 bool GUI::textIsScrolling = false; ///< Our selected row/text is now scrolling/anim
+probeProgInfo* GUI::curProbingProgress = nullptr;
 #if SDSUPPORT
 char GUI::cwd[SD_MAX_FOLDER_DEPTH * LONG_FILENAME_LENGTH + 2] = { '/', 0 };
 uint8_t GUI::folderLevel = 0;

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -37,6 +37,7 @@ void GUI::refresh() {
 
 void GUI::resetMenu() { } ///< Go to start page
 
+void __attribute__((weak)) probeProgress(GUIAction action, void* data) { }
 void __attribute__((weak)) startScreen(GUIAction action, void* data) { }
 void __attribute__((weak)) waitScreen(GUIAction action, void* data) { }
 void __attribute__((weak)) infoScreen(GUIAction action, void* data) { }

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -78,18 +78,6 @@ enum class GUIStatusLevel {
     WARNING = 3, // Popup warning
     ERROR = 4    // Popup error
 };
-
-struct probeProgInfo { 
-    explicit probeProgInfo(const float& _x, const float& _y, const float& _z, const uint16_t& _num, const uint16_t _maxNum)
-        : x(_x)
-        , y(_y)
-        , z(_z)
-        , num(_num)
-        , maxNum(_maxNum) { }
-    const float &x, &y, &z;
-    const uint16_t &num, maxNum;
-};
-
 typedef void (*GuiCallback)(GUIAction action, void* data);
 
 extern void startScreen(GUIAction action, void* data);
@@ -149,6 +137,7 @@ extern void selectToolAction(GUIAction action, void* data);
         GUI::clearStatus(); \
     }
 
+struct probeProgInfo;
 class GUI {
 public:
     static int level;                            // Menu level for back handling
@@ -171,6 +160,7 @@ public:
     static int nextActionRepeat;                 ///< Increment for next/previous
     static GUIStatusLevel statusLevel;
     static bool textIsScrolling;
+    static probeProgInfo* curProbingProgress;    ///< Pointer to a valid current probing datastruct
 #if SDSUPPORT
     static char cwd[SD_MAX_FOLDER_DEPTH * LONG_FILENAME_LENGTH + 2];
     static uint8_t folderLevel;
@@ -245,6 +235,22 @@ public:
     static bool handleFloatValueAction(GUIAction& action, float& value, float min, float max, float increment);
     static bool handleFloatValueAction(GUIAction& action, float& value, float increment);
     static bool handleLongValueAction(GUIAction& action, int32_t& value, int32_t min, int32_t max, int32_t increment);
+};
+
+struct probeProgInfo {
+    explicit probeProgInfo(const float& _x, const float& _y, const float& _z, const uint16_t& _num, const uint16_t _maxNum)
+        : x(_x)
+        , y(_y)
+        , z(_z)
+        , num(_num)
+        , maxNum(_maxNum) {
+        GUI::curProbingProgress = this;
+    }
+    const float &x, &y, &z;
+    const uint16_t &num, maxNum;
+    ~probeProgInfo() {
+        GUI::curProbingProgress = nullptr;
+    }
 };
 
 #define DRAW_FLOAT_P(text, unit, val, prec) \

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -79,6 +79,17 @@ enum class GUIStatusLevel {
     ERROR = 4    // Popup error
 };
 
+struct probeProgInfo { 
+    explicit probeProgInfo(const float& _x, const float& _y, const float& _z, const uint16_t& _num, const uint16_t _maxNum)
+        : x(_x)
+        , y(_y)
+        , z(_z)
+        , num(_num)
+        , maxNum(_maxNum) { }
+    const float &x, &y, &z;
+    const uint16_t &num, maxNum;
+};
+
 typedef void (*GuiCallback)(GUIAction action, void* data);
 
 extern void startScreen(GUIAction action, void* data);

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -83,6 +83,7 @@ typedef void (*GuiCallback)(GUIAction action, void* data);
 
 extern void startScreen(GUIAction action, void* data);
 extern void printProgress(GUIAction action, void* data);
+extern void probeProgress(GUIAction action, void* data);
 extern void mainMenu(GUIAction action, void* data);
 extern void startScreen(GUIAction action, void* data);
 extern void warningScreen(GUIAction action, void* data);

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -319,6 +319,8 @@ bool Leveling::measure(uint8_t gridSize) {
                         dispZ = diff;
                         GUI::contentChanged = true;
                         builder.addPoint(px, py, h);
+                    } else if (h == ILLEGAL_Z_PROBE) {
+                        dispZ = ILLEGAL_Z_PROBE;
                     }
                 }
             } else {

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -281,7 +281,7 @@ bool Leveling::measure(uint8_t gridSize) {
     uint16_t curNum = 0;
     float dispZ = IGNORE_COORDINATE;
     probeProgInfo dat(px, py, dispZ, curNum, probePoints);
-    GUI::push(probeProgress, &dat, GUIPageType::BUSY);
+    GUI::push(probeProgress, nullptr, GUIPageType::BUSY);
 
     Motion1::copyCurrentPrinter(pos);
     bool ok = true;

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -273,6 +273,21 @@ bool Leveling::measure(uint8_t gridSize) {
     if (!ZProbeHandler::activate()) {
         return false;
     }
+
+    constexpr uint16_t probePoints = GRID_SIZE * GRID_SIZE;
+    Com::printF(PSTR("Beginning autolevel with "), probePoints);
+    Com::printFLN(PSTR(" grid points..."));
+
+    // Living dangerously.
+    struct {
+        float pointHeight = IGNORE_COORDINATE;
+        ufast8_t posX = 0;
+        ufast8_t posY = 0;
+        ufast8_t pointNum = 0;
+    } guiData;
+    guiData.posX = px;
+    guiData.posY = py;
+    GUI::push(probeProgress, static_cast<void*>(&guiData), GUIPageType::BUSY);
     Motion1::copyCurrentPrinter(pos);
     bool ok = true;
     float tempDx = (xMax - xMin) / (gridSize - 1);
@@ -303,6 +318,13 @@ bool Leveling::measure(uint8_t gridSize) {
                     ok &= h != ILLEGAL_Z_PROBE;
                     grid[xx][y] = h;
                     if (ok) {
+                        uint16_t count = ((y * GRID_SIZE) + x) + 1;
+                        float diff = ZProbeHandler::getBedDistance() - h;
+                        guiData.pointHeight = diff;
+                        guiData.posX = px;
+                        guiData.posY = py;
+                        guiData.pointNum = count;
+                        GUI::contentChanged = true;
                         builder.addPoint(px, py, h);
                     }
                 }
@@ -321,6 +343,7 @@ bool Leveling::measure(uint8_t gridSize) {
 #endif
     ZProbeHandler::deactivate();
     if (ok && !Printer::breakLongCommand) {
+        GUI::setStatusP(PSTR("Autolevel complete!"), GUIStatusLevel::INFO);
 #if NUM_HEATED_BEDS
         gridTemp = heatedBeds[0]->getTargetTemperature();
 #endif
@@ -341,8 +364,13 @@ bool Leveling::measure(uint8_t gridSize) {
         setDistortionEnabled(true); // if we support it we should use it by default
         reportDistortionStatus();
 #endif
-    } else if (!ok) {
-        resetEeprom();
+    } else {
+        GUI::pop();
+        GUI::setStatusP(Com::tEmpty, GUIStatusLevel::REGULAR);
+        GUI::contentChanged = true;
+        if (!ok) {
+            resetEeprom();
+        }
     }
     Motion1::printCurrentPosition();
     return ok;


### PR DESCRIPTION
Adds a small animated leveling progress screen for both 20x4's and u8g2's. 
This is primarily for grid based leveling since it can take a fair bit of time.
But I believe it could be fit to work with the other leveling methods too.

(Sorry about the u8g2's probeProgress function being somewhat visually bloated, used a fair bit of constexpr margin variables to handle things.)

It looks like this:
![image](https://user-images.githubusercontent.com/34206147/99843439-90f76b00-2b3f-11eb-8c8f-097c32b5fc0d.png)




