### PR TITLE
ZProbe - G32 add R<repetitions> A<useMedian>

### DIFF
--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -859,12 +859,10 @@ void ZProbeHandler::deactivate() {
     }
 }
 
-float ZProbeHandler::runProbe() {
+float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     Motion1::callBeforeHomingOnSteppers();
     float zCorr = 0;
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN && Z_PROBE_REPETITIONS > 1
-    float measurements[Z_PROBE_REPETITIONS];
-#endif
+    float measurements[constrain(repetitions, 1, 10)] = { 0.0f };
     if (ZProbe->update()) {
         Com::printErrorFLN(PSTR("z-probe triggered before starting probing."));
         Motion1::callAfterHomingOnSteppers();
@@ -893,7 +891,7 @@ float ZProbeHandler::runProbe() {
     Motion1::copyCurrentPrinter(tPos);
 
     float secureDistance = (Motion1::maxPos[Z_AXIS] - Motion1::minPos[Z_AXIS]) * 1.5f;
-    if (Motion1::currentPosition[Z_AXIS] > 0.5 * ZProbeHandler::optimumProbingHeight() + 0.1 && fabsf(Motion1::currentPosition[Z_AXIS] - ZProbeHandler::optimumProbingHeight()) < 1.0f) {
+    if (Motion1::currentPosition[Z_AXIS] > 0.5f * ZProbeHandler::optimumProbingHeight() + 0.1f && fabsf(Motion1::currentPosition[Z_AXIS] - ZProbeHandler::optimumProbingHeight()) < 1.0f) {
         secureDistance = getBedDistance() * 1.5f;
     }
     tPos[Z_AXIS] -= secureDistance;
@@ -914,104 +912,100 @@ float ZProbeHandler::runProbe() {
     }
 
     float z = secureDistance * ((fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]));
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN && Z_PROBE_REPETITIONS > 1
     measurements[0] = z;
-#endif
     FOR_ALL_AXES(i) {
         int32_t df = cPosSteps[i] - tPosSteps[i];
         corSteps[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
     }
     float zr = 0.0f;
-#if Z_PROBE_REPETITIONS > 1
-    // We are now at z=0 do repetitions and assume correct them 100%
-    float cPos2[NUM_AXES], tPos2[NUM_AXES], tPos3[NUM_AXES];
-    FOR_ALL_AXES(i) {
-        cPos2[i] = cPos[i];
-        tPos2[i] = cPos[i];
-        tPos3[i] = cPos[i];
-    }
-    // Go up to start position for repeated tests
-    cPos2[Z_AXIS] = 0;
-    FOR_ALL_AXES(i) {
-        Motion1::currentPositionTransformed[i] = cPos2[i];
-    }
-    Motion1::updatePositionsFromCurrentTransformed();
-    Motion2::setMotorPositionFromTransformed();
-    Motion1::endstopMode = EndstopMode::DISABLED;
-    tPos2[Z_AXIS] = Z_PROBE_SWITCHING_DISTANCE;
-    tPos3[Z_AXIS] = -1.0f;
-    int32_t cPosSteps2[NUM_AXES], tPosSteps2[NUM_AXES], tPosSteps3[NUM_AXES], corSteps2[NUM_AXES];
-    PrinterType::transform(cPos2, cPosSteps2);
-    PrinterType::transform(tPos2, tPosSteps2);
-    PrinterType::transform(tPos3, tPosSteps3);
-    Motion1::moveByPrinter(tPos2, Motion1::moveFeedrate[Z_AXIS], false);
-    Motion1::waitForEndOfMoves();
-#ifdef Z_PROBE_RUN_AFTER_EVERY_PROBE
-    GCode::executeFString(PSTR(Z_PROBE_RUN_AFTER_EVERY_PROBE));
-#endif
-
-    for (fast8_t r = 1; r < Z_PROBE_REPETITIONS; r++) {
-        // Go down
-#if defined(Z_PROBE_DELAY) && Z_PROBE_DELAY > 0
-        HAL::delayMilliseconds(Z_PROBE_DELAY);
-#endif
-        Motion1::stepsRemaining[Z_AXIS] = 0;
-        Motion1::endstopMode = EndstopMode::PROBING;
-        Motion1::moveByPrinter(tPos3, speed, false);
-        Motion1::waitForEndOfMoves();
-        Motion1::endstopMode = EndstopMode::DISABLED;
-
-        if (Motion1::stepsRemaining[Z_AXIS] < Z_CRASH_THRESHOLD_STEPS) {
-            Com::printErrorFLN(PSTR("Failed to trigger probe endstop! Bed crash?"));
-            Motion1::callAfterHomingOnSteppers();
-            return ILLEGAL_Z_PROBE;
-        }
-
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-        measurements[r] = z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
-#else
-        zr += z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
-#endif
-        // Go up to tPos2
+    if (repetitions > 1) {
+        // We are now at z=0 do repetitions and assume correct them 100%
+        float cPos2[NUM_AXES], tPos2[NUM_AXES], tPos3[NUM_AXES];
         FOR_ALL_AXES(i) {
-            int32_t df = tPosSteps2[i] - tPosSteps3[i];
-            corSteps2[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
+            cPos2[i] = cPos[i];
+            tPos2[i] = cPos[i];
+            tPos3[i] = cPos[i];
         }
-        Motion1::moveRelativeBySteps(corSteps2);
-        Motion1::waitForEndOfMoves();
+        // Go up to start position for repeated tests
+        cPos2[Z_AXIS] = 0.0f;
         FOR_ALL_AXES(i) {
-            Motion1::currentPositionTransformed[i] = tPos2[i];
+            Motion1::currentPositionTransformed[i] = cPos2[i];
         }
         Motion1::updatePositionsFromCurrentTransformed();
         Motion2::setMotorPositionFromTransformed();
-    }
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-    // bubble sort the measurements
-    float tmp;
-    for (fast8_t i = 0; i < Z_PROBE_REPETITIONS - 1; i++) {         // n numbers require at most n-1 rounds of swapping
-        for (fast8_t j = 0; j < Z_PROBE_REPETITIONS - i - 1; j++) { //
-            if (measurements[j] > measurements[j + 1]) {            // out of order?
-                tmp = measurements[j];                              // swap them:
-                measurements[j] = measurements[j + 1];
-                measurements[j + 1] = tmp;
+
+        Motion1::endstopMode = EndstopMode::DISABLED;
+        tPos2[Z_AXIS] = Z_PROBE_SWITCHING_DISTANCE;
+        tPos3[Z_AXIS] = -1.0f;
+        int32_t cPosSteps2[NUM_AXES], tPosSteps2[NUM_AXES], tPosSteps3[NUM_AXES], corSteps2[NUM_AXES] = { 0 };
+
+        PrinterType::transform(cPos2, cPosSteps2);
+        PrinterType::transform(tPos2, tPosSteps2);
+        PrinterType::transform(tPos3, tPosSteps3);
+        tPos2[E_AXIS] = IGNORE_COORDINATE;
+        Motion1::moveByPrinter(tPos2, Motion1::maxFeedrate[X_AXIS], false);
+        Motion1::waitForEndOfMoves();
+#ifdef Z_PROBE_RUN_AFTER_EVERY_PROBE
+        GCode::executeFString(PSTR(Z_PROBE_RUN_AFTER_EVERY_PROBE));
+#endif
+
+        for (fast8_t r = 1; r < repetitions && !Printer::breakLongCommand; r++) {
+            // Go down
+#if defined(Z_PROBE_DELAY) && Z_PROBE_DELAY > 0
+            HAL::delayMilliseconds(Z_PROBE_DELAY);
+#endif
+            Motion1::stepsRemaining[Z_AXIS] = 0;
+            Motion1::endstopMode = EndstopMode::PROBING;
+            tPos3[E_AXIS] = IGNORE_COORDINATE;
+            Motion1::moveByPrinter(tPos3, speed, false);
+            Motion1::waitForEndOfMoves();
+            Motion1::endstopMode = EndstopMode::DISABLED;
+
+            if (Motion1::stepsRemaining[Z_AXIS] < Z_CRASH_THRESHOLD_STEPS) {
+                Com::printErrorFLN(PSTR("Failed to trigger probe endstop! Bed crash?"));
+                Motion1::callAfterHomingOnSteppers();
+                return ILLEGAL_Z_PROBE;
             }
+
+            if (useMedian) {
+                measurements[r] = z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0f) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
+            } else {
+                zr += z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0f) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
+            }
+            // Go up to tPos2
+            FOR_ALL_AXES(i) {
+                int32_t df = tPosSteps2[i] - tPosSteps3[i];
+                corSteps2[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
+            }
+            Motion1::moveRelativeBySteps(corSteps2);
+            Motion1::waitForEndOfMoves();
+            FOR_ALL_AXES(i) {
+                Motion1::currentPositionTransformed[i] = tPos2[i];
+            }
+            Motion1::updatePositionsFromCurrentTransformed();
+            Motion2::setMotorPositionFromTransformed();
+        }
+        if (useMedian) {
+            //Com::printArrayFLN("measure: ", measurements, ARRAY_SIZE(measurements), 4);
+            float tmp;
+            for (fast8_t i = 0; i < repetitions - 1; i++) {         // n numbers require at most n-1 rounds of swapping
+                for (fast8_t j = 0; j < repetitions - i - 1; j++) { //
+                    if (measurements[j] > measurements[j + 1]) {    // out of order?
+                        tmp = measurements[j];                      // swap them:
+                        measurements[j] = measurements[j + 1];
+                        measurements[j + 1] = tmp;
+                    }
+                }
+            }
+            z = static_cast<float>(measurements[repetitions >> 1u]);
+        } else {
+            z = (z + zr) / static_cast<float>(repetitions);
+        }
+        // Fix last correction
+        FOR_ALL_AXES(i) {
+            corSteps[i] -= corSteps2[i];
         }
     }
-    // Take median result
-    z = static_cast<float>(measurements[Z_PROBE_REPETITIONS >> 1]);
-#else
-    z = (z + zr) / static_cast<float>(Z_PROBE_REPETITIONS);
-#endif
-    // Fix last correction
-    FOR_ALL_AXES(i) {
-        corSteps[i] -= corSteps2[i];
-    }
-#endif
-#if ENABLE_BUMP_CORRECTION
-    // if (Leveling::isDistortionEnabled()) {
-    // zCorr = Leveling::distortionAt(Motion1::currentPosition[X_AXIS], Motion1::currentPosition[Y_AXIS]);
-    // }
-#endif
     z += height;
     z -= zCorr;
     /* DEBUG_MSG2_FAST("StartSteps", cPosSteps[Z_AXIS]);

--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -114,7 +114,7 @@ void ZProbeHandler::deactivate() {
 
 float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     Motion1::callBeforeHomingOnSteppers();
-    float measurements[constrain(repetitions, 1u, 10u)] = { 0.0f };
+    float measurements[repetitions = constrain(repetitions, 1u, 10u)] = { 0.0f };
     if (ZProbe->update()) {
         Com::printErrorFLN(PSTR("z-probe triggered before starting probing."));
         Motion1::callAfterHomingOnSteppers();
@@ -476,7 +476,7 @@ void ZProbeHandler::deactivate() {
 
 float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     Motion1::callBeforeHomingOnSteppers();
-    float measurements[constrain(repetitions, 1u, 10u)] = { 0.0f };
+    float measurements[repetitions = constrain(repetitions, 1u, 10u)] = { 0.0f };
     if (ZProbe->update()) {
         Com::printErrorFLN(PSTR("z-probe triggered before starting probing."));
         Motion1::callAfterHomingOnSteppers();
@@ -830,7 +830,7 @@ void ZProbeHandler::deactivate() {
 
 float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     Motion1::callBeforeHomingOnSteppers();
-    float measurements[constrain(repetitions, 1u, 10u)] = { 0.0f };
+    float measurements[repetitions = constrain(repetitions, 1u, 10u)] = { 0.0f };
     if (ZProbe->update()) {
         Com::printErrorFLN(PSTR("z-probe triggered before starting probing."));
         Motion1::callAfterHomingOnSteppers();

--- a/src/Repetier/src/drivers/zprobe.cpp
+++ b/src/Repetier/src/drivers/zprobe.cpp
@@ -60,6 +60,7 @@ bool ZProbeHandler::activate() {
     float cPos[NUM_AXES];
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, offsetX, offsetY, Z_PROBE_BORDER);
+    cPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     GCode::executeFString(Com::tZProbeStartScript);
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
@@ -94,6 +95,7 @@ void ZProbeHandler::deactivate() {
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, tool->getOffsetX(), tool->getOffsetY(), Z_PROBE_BORDER);
     GCode::executeFString(Com::tZProbeEndScript);
+    cPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     Motion1::setToolOffset(-tool->getOffsetX(), -tool->getOffsetY(), -tool->getOffsetZ());
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
@@ -110,12 +112,9 @@ void ZProbeHandler::deactivate() {
     }
 }
 
-float ZProbeHandler::runProbe() {
+float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     Motion1::callBeforeHomingOnSteppers();
-    float zCorr = 0;
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-    float measurements[Z_PROBE_REPETITIONS];
-#endif
+    float measurements[constrain(repetitions, 1u, 10u)] = { 0.0f };
     if (ZProbe->update()) {
         Com::printErrorFLN(PSTR("z-probe triggered before starting probing."));
         Motion1::callAfterHomingOnSteppers();
@@ -123,9 +122,6 @@ float ZProbeHandler::runProbe() {
     }
     if (Leveling::isDistortionEnabled()) {
         Com::printWarningFLN(PSTR("z-probe with distortion enabled can return unexpected results!"));
-        // Com::printErrorFLN(PSTR("z-probe stopped because bump correction is active. This will influence the result."));
-        // Motion1::callAfterHomingOnSteppers();
-        // return ILLEGAL_Z_PROBE;
     }
     bool wasActivated = activated;
     if (!activated) {
@@ -136,7 +132,7 @@ float ZProbeHandler::runProbe() {
     EndstopMode oldMode = Motion1::endstopMode;
     Motion1::endstopMode = EndstopMode::PROBING;
     Motion1::waitForEndOfMoves(); // defined starting condition
-    Motion1::stopMask = 4;        // z trigger is finished
+    Motion1::stopMask = 4u;       // z trigger is finished
     float cPos[NUM_AXES], tPos[NUM_AXES];
     int32_t cPosSteps[NUM_AXES], tPosSteps[NUM_AXES], corSteps[NUM_AXES];
     Motion1::copyCurrentPrinter(cPos);
@@ -144,7 +140,7 @@ float ZProbeHandler::runProbe() {
     Motion1::copyCurrentPrinter(tPos);
 
     float secureDistance = (Motion1::maxPos[Z_AXIS] - Motion1::minPos[Z_AXIS]) * 1.5f;
-    if (Motion1::currentPosition[Z_AXIS] > 0.5 * ZProbeHandler::optimumProbingHeight() + 0.1 && fabsf(Motion1::currentPosition[Z_AXIS] - ZProbeHandler::optimumProbingHeight()) < 1.0f) {
+    if (Motion1::currentPosition[Z_AXIS] > 0.5f * ZProbeHandler::optimumProbingHeight() + 0.1f && fabsf(Motion1::currentPosition[Z_AXIS] - ZProbeHandler::optimumProbingHeight()) < 1.0f) {
         secureDistance = getBedDistance() * 1.5f;
     }
     tPos[Z_AXIS] -= secureDistance;
@@ -154,6 +150,7 @@ float ZProbeHandler::runProbe() {
     HAL::delayMilliseconds(Z_PROBE_DELAY);
 #endif
     Motion1::stepsRemaining[Z_AXIS] = 0;
+    tPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByPrinter(tPos, speed, false);
     Motion1::waitForEndOfMoves();
     Motion1::endstopMode = EndstopMode::DISABLED;
@@ -164,107 +161,101 @@ float ZProbeHandler::runProbe() {
         return ILLEGAL_Z_PROBE;
     }
     float z = secureDistance * ((fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]));
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-    measurements[0] = z;
-#endif
+    measurements[0u] = z;
     FOR_ALL_AXES(i) {
         int32_t df = cPosSteps[i] - tPosSteps[i];
         corSteps[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
     }
     float zr = 0.0f;
-#if Z_PROBE_REPETITIONS > 1
-    // We are now at z=0 do repetitions and assume correct them 100%
-    float cPos2[NUM_AXES], tPos2[NUM_AXES], tPos3[NUM_AXES];
-    FOR_ALL_AXES(i) {
-        cPos2[i] = cPos[i];
-        tPos2[i] = cPos[i];
-        tPos3[i] = cPos[i];
-    }
-    // Go up to start position for repeated tests
-    cPos2[Z_AXIS] = 0;
-    FOR_ALL_AXES(i) {
-        Motion1::currentPositionTransformed[i] = cPos2[i];
-    }
-    Motion1::updatePositionsFromCurrentTransformed();
-    Motion2::setMotorPositionFromTransformed();
-    Motion1::endstopMode = EndstopMode::DISABLED;
-    tPos2[Z_AXIS] = Z_PROBE_SWITCHING_DISTANCE;
-    tPos3[Z_AXIS] = -1.0f;
-    int32_t cPosSteps2[NUM_AXES], tPosSteps2[NUM_AXES], tPosSteps3[NUM_AXES], corSteps2[NUM_AXES];
-    PrinterType::transform(cPos2, cPosSteps2);
-    PrinterType::transform(tPos2, tPosSteps2);
-    PrinterType::transform(tPos3, tPosSteps3);
-    Motion1::moveByPrinter(tPos2, Motion1::moveFeedrate[Z_AXIS], false);
-    Motion1::waitForEndOfMoves();
-#ifdef Z_PROBE_RUN_AFTER_EVERY_PROBE
-    GCode::executeFString(PSTR(Z_PROBE_RUN_AFTER_EVERY_PROBE));
-#endif
-
-    for (fast8_t r = 1; r < Z_PROBE_REPETITIONS; r++) {
-        // Go down
-#if defined(Z_PROBE_DELAY) && Z_PROBE_DELAY > 0
-        HAL::delayMilliseconds(Z_PROBE_DELAY);
-#endif
-        Motion1::stepsRemaining[Z_AXIS] = 0;
-        Motion1::endstopMode = EndstopMode::PROBING;
-        Motion1::moveByPrinter(tPos3, speed, false);
-        Motion1::waitForEndOfMoves();
-        Motion1::endstopMode = EndstopMode::DISABLED;
-
-        if (Motion1::stepsRemaining[Z_AXIS] < Z_CRASH_THRESHOLD_STEPS) {
-            Com::printErrorFLN(PSTR("Failed to trigger probe endstop! Bed crash?"));
-            Motion1::callAfterHomingOnSteppers();
-            return ILLEGAL_Z_PROBE;
-        }
-
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-        measurements[r] = z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
-#else
-        zr += z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
-#endif
-        // Go up to tPos2
+    if (repetitions > 1u) {
+        // We are now at z=0 do repetitions and assume correct them 100%
+        float cPos2[NUM_AXES], tPos2[NUM_AXES], tPos3[NUM_AXES];
         FOR_ALL_AXES(i) {
-            int32_t df = tPosSteps2[i] - tPosSteps3[i];
-            corSteps2[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
+            cPos2[i] = cPos[i];
+            tPos2[i] = cPos[i];
+            tPos3[i] = cPos[i];
         }
-        Motion1::moveRelativeBySteps(corSteps2);
-        Motion1::waitForEndOfMoves();
+        // Go up to start position for repeated tests
+        cPos2[Z_AXIS] = 0.0f;
         FOR_ALL_AXES(i) {
-            Motion1::currentPositionTransformed[i] = tPos2[i];
+            Motion1::currentPositionTransformed[i] = cPos2[i];
         }
         Motion1::updatePositionsFromCurrentTransformed();
         Motion2::setMotorPositionFromTransformed();
-    }
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-    // bubble sort the measurements
-    float tmp;
-    for (fast8_t i = 0; i < Z_PROBE_REPETITIONS - 1; i++) {         // n numbers require at most n-1 rounds of swapping
-        for (fast8_t j = 0; j < Z_PROBE_REPETITIONS - i - 1; j++) { //
-            if (measurements[j] > measurements[j + 1]) {            // out of order?
-                tmp = measurements[j];                              // swap them:
-                measurements[j] = measurements[j + 1];
-                measurements[j + 1] = tmp;
+        Motion1::endstopMode = EndstopMode::DISABLED;
+        tPos2[Z_AXIS] = Z_PROBE_SWITCHING_DISTANCE;
+        tPos3[Z_AXIS] = -1.0f;
+        int32_t cPosSteps2[NUM_AXES], tPosSteps2[NUM_AXES], tPosSteps3[NUM_AXES], corSteps2[NUM_AXES] = { 0 };
+        PrinterType::transform(cPos2, cPosSteps2);
+        PrinterType::transform(tPos2, tPosSteps2);
+        PrinterType::transform(tPos3, tPosSteps3);
+        tPos2[E_AXIS] = IGNORE_COORDINATE;
+        Motion1::moveByPrinter(tPos2, Motion1::maxFeedrate[X_AXIS], false);
+        Motion1::waitForEndOfMoves();
+#ifdef Z_PROBE_RUN_AFTER_EVERY_PROBE
+        GCode::executeFString(PSTR(Z_PROBE_RUN_AFTER_EVERY_PROBE));
+#endif
+
+        for (fast8_t r = 1; r < repetitions && !Printer::breakLongCommand; r++) {
+            // Go down
+#if defined(Z_PROBE_DELAY) && Z_PROBE_DELAY > 0
+            HAL::delayMilliseconds(Z_PROBE_DELAY);
+#endif
+            Motion1::stepsRemaining[Z_AXIS] = 0;
+            Motion1::endstopMode = EndstopMode::PROBING;
+            tPos3[E_AXIS] = IGNORE_COORDINATE;
+            Motion1::moveByPrinter(tPos3, speed, false);
+            Motion1::waitForEndOfMoves();
+            Motion1::endstopMode = EndstopMode::DISABLED;
+
+            if (Motion1::stepsRemaining[Z_AXIS] < Z_CRASH_THRESHOLD_STEPS) {
+                Com::printErrorFLN(PSTR("Failed to trigger probe endstop! Bed crash?"));
+                Motion1::callAfterHomingOnSteppers();
+                return ILLEGAL_Z_PROBE;
             }
+
+            if (useMedian) {
+                measurements[r] = z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0f) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
+            } else {
+                zr += z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0f) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
+            }
+            // Go up to tPos2
+            FOR_ALL_AXES(i) {
+                int32_t df = tPosSteps2[i] - tPosSteps3[i];
+                corSteps2[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
+            }
+            Motion1::moveRelativeBySteps(corSteps2);
+            Motion1::waitForEndOfMoves();
+            FOR_ALL_AXES(i) {
+                Motion1::currentPositionTransformed[i] = tPos2[i];
+            }
+            Motion1::updatePositionsFromCurrentTransformed();
+            Motion2::setMotorPositionFromTransformed();
+        }
+        if (useMedian) {
+            //Com::printArrayFLN("measure: ", measurements, ARRAY_SIZE(measurements), 4);
+            float tmp;
+            for (fast8_t i = 0; i < repetitions - 1; i++) {         // n numbers require at most n-1 rounds of swapping
+                for (fast8_t j = 0; j < repetitions - i - 1; j++) { //
+                    if (measurements[j] > measurements[j + 1]) {    // out of order?
+                        tmp = measurements[j];                      // swap them:
+                        measurements[j] = measurements[j + 1];
+                        measurements[j + 1] = tmp;
+                    }
+                }
+            }
+            // Take median result
+            z = static_cast<float>(measurements[repetitions >> 1u]);
+        } else {
+            z = (z + zr) / static_cast<float>(repetitions);
+        }
+        // Fix last correction
+        FOR_ALL_AXES(i) {
+            corSteps[i] -= corSteps2[i];
         }
     }
-    // Take median result
-    z = static_cast<float>(measurements[Z_PROBE_REPETITIONS >> 1]);
-#else
-    z = (z + zr) / static_cast<float>(Z_PROBE_REPETITIONS);
-#endif
-    // Fix last correction
-    FOR_ALL_AXES(i) {
-        corSteps[i] -= corSteps2[i];
-    }
-#endif
-#if ENABLE_BUMP_CORRECTION
-    // if (Leveling::isDistortionEnabled()) {
-    // zCorr = Leveling::distortionAt(Motion1::currentPosition[X_AXIS], Motion1::currentPosition[Y_AXIS]);
-    // }
-#endif
     z += height;
     z -= coating;
-    z -= zCorr;
     /* DEBUG_MSG2_FAST("StartSteps", cPosSteps[Z_AXIS]);
     DEBUG_MSG2_FAST("EndSteps", tPosSteps[Z_AXIS]);
     DEBUG_MSG2_FAST("CorSteps", corSteps[Z_AXIS]);
@@ -291,7 +282,8 @@ float ZProbeHandler::runProbe() {
     }
     if (ZProbe->update()) {
         millis_t startTime = HAL::timeInMilliseconds();
-        while (ZProbe->update() && ((HAL::timeInMilliseconds() - startTime) < 200)) {
+        // wait up to 200ms to be sure signal stays
+        while (ZProbe->update() && ((HAL::timeInMilliseconds() - startTime) < 200ul)) {
             Commands::checkForPeriodicalActions(false);
         }
 
@@ -301,18 +293,10 @@ float ZProbeHandler::runProbe() {
             return ILLEGAL_Z_PROBE;
         }
     }
+    Motion1::waitForEndOfMoves();
     Com::printF(Com::tZProbe, z, 3);
     Com::printF(Com::tSpaceXColon, Motion1::currentPosition[X_AXIS]);
-#if ENABLE_BUMP_CORRECTION
-    if (Leveling::isDistortionEnabled()) {
-        Com::printF(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-        Com::printFLN(PSTR(" zCorr:"), zCorr, 3);
-    } else {
-        Com::printFLN(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-    }
-#else
     Com::printFLN(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-#endif
     Motion1::callAfterHomingOnSteppers();
     return z;
 }
@@ -421,6 +405,7 @@ bool ZProbeHandler::activate() {
     Tool* tool = Tool::getActiveTool();
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, tool->getOffsetX(), tool->getOffsetY(), Z_PROBE_BORDER);
+    cPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     GCode::executeFString(Com::tZProbeStartScript);
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
@@ -468,6 +453,7 @@ void ZProbeHandler::deactivate() {
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, tool->getOffsetX(), tool->getOffsetY(), Z_PROBE_BORDER);
     GCode::executeFString(Com::tZProbeEndScript);
+    cPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     Motion1::setToolOffset(-tool->getOffsetX(), -tool->getOffsetY(), -tool->getOffsetZ());
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
@@ -488,12 +474,9 @@ void ZProbeHandler::deactivate() {
     }
 }
 
-float ZProbeHandler::runProbe() {
-    float zCorr = 0;
+float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     Motion1::callBeforeHomingOnSteppers();
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN && Z_PROBE_REPETITIONS > 1
-    float measurements[Z_PROBE_REPETITIONS];
-#endif
+    float measurements[constrain(repetitions, 1u, 10u)] = { 0.0f };
     if (ZProbe->update()) {
         Com::printErrorFLN(PSTR("z-probe triggered before starting probing."));
         Motion1::callAfterHomingOnSteppers();
@@ -501,9 +484,6 @@ float ZProbeHandler::runProbe() {
     }
     if (Leveling::isDistortionEnabled()) {
         Com::printWarningFLN(PSTR("z-probe with distortion enabled can return unexpected results!"));
-        // Com::printErrorFLN(PSTR("z-probe stopped because bump correction is active. This will influence the result."));
-        // Motion1::callAfterHomingOnSteppers();
-        // return ILLEGAL_Z_PROBE;
     }
     bool wasActivated = activated;
     if (!activated) {
@@ -511,11 +491,10 @@ float ZProbeHandler::runProbe() {
     }
     bool alActive = Motion1::isAutolevelActive();
     Motion1::setAutolevelActive(false, true);
-    // bool bcActive = Leveling::isDistortionEnabled();
     EndstopMode oldMode = Motion1::endstopMode;
     Motion1::endstopMode = EndstopMode::PROBING;
     Motion1::waitForEndOfMoves(); // defined starting condition
-    Motion1::stopMask = 4;        // z trigger is finished
+    Motion1::stopMask = 4u;       // z trigger is finished
     float cPos[NUM_AXES], tPos[NUM_AXES];
     int32_t cPosSteps[NUM_AXES], tPosSteps[NUM_AXES], corSteps[NUM_AXES];
     Motion1::copyCurrentPrinter(cPos);
@@ -523,7 +502,7 @@ float ZProbeHandler::runProbe() {
     Motion1::copyCurrentPrinter(tPos);
 
     float secureDistance = (Motion1::maxPos[Z_AXIS] - Motion1::minPos[Z_AXIS]) * 1.5f;
-    if (Motion1::currentPosition[Z_AXIS] > 0.5 * ZProbeHandler::optimumProbingHeight() + 0.1 && fabsf(Motion1::currentPosition[Z_AXIS] - ZProbeHandler::optimumProbingHeight()) < 1.0f) {
+    if (Motion1::currentPosition[Z_AXIS] > 0.5f * ZProbeHandler::optimumProbingHeight() + 0.1f && fabsf(Motion1::currentPosition[Z_AXIS] - ZProbeHandler::optimumProbingHeight()) < 1.0f) {
         secureDistance = getBedDistance() * 1.5f;
     }
     tPos[Z_AXIS] -= secureDistance;
@@ -533,6 +512,7 @@ float ZProbeHandler::runProbe() {
     HAL::delayMilliseconds(Z_PROBE_DELAY);
 #endif
     Motion1::stepsRemaining[Z_AXIS] = 0;
+    tPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByPrinter(tPos, speed, false);
     Motion1::waitForEndOfMoves();
     Motion1::endstopMode = EndstopMode::DISABLED;
@@ -544,106 +524,100 @@ float ZProbeHandler::runProbe() {
     }
 
     float z = secureDistance * ((fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]));
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN && Z_PROBE_REPETITIONS > 1
-    measurements[0] = z;
-#endif
+    measurements[0u] = z;
     FOR_ALL_AXES(i) {
         int32_t df = cPosSteps[i] - tPosSteps[i];
         corSteps[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
     }
     float zr = 0.0f;
-#if Z_PROBE_REPETITIONS > 1
-    // We are now at z=0 do repetitions and assume correct them 100%
-    float cPos2[NUM_AXES], tPos2[NUM_AXES], tPos3[NUM_AXES];
-    FOR_ALL_AXES(i) {
-        cPos2[i] = cPos[i];
-        tPos2[i] = cPos[i];
-        tPos3[i] = cPos[i];
-    }
-    // Go up to start position for repeated tests
-    cPos2[Z_AXIS] = 0;
-    FOR_ALL_AXES(i) {
-        Motion1::currentPositionTransformed[i] = cPos2[i];
-    }
-    Motion1::updatePositionsFromCurrentTransformed();
-    Motion2::setMotorPositionFromTransformed();
-    Motion1::endstopMode = EndstopMode::DISABLED;
-    tPos2[Z_AXIS] = Z_PROBE_SWITCHING_DISTANCE;
-    tPos3[Z_AXIS] = -1.0f;
-    int32_t cPosSteps2[NUM_AXES], tPosSteps2[NUM_AXES], tPosSteps3[NUM_AXES], corSteps2[NUM_AXES];
-    PrinterType::transform(cPos2, cPosSteps2);
-    PrinterType::transform(tPos2, tPosSteps2);
-    PrinterType::transform(tPos3, tPosSteps3);
-    Motion1::moveByPrinter(tPos2, Motion1::moveFeedrate[Z_AXIS], false);
-    Motion1::waitForEndOfMoves();
-#ifdef Z_PROBE_RUN_AFTER_EVERY_PROBE
-    GCode::executeFString(PSTR(Z_PROBE_RUN_AFTER_EVERY_PROBE));
-#endif
-
-    for (fast8_t r = 1; r < Z_PROBE_REPETITIONS; r++) {
-        // Go down
-#if defined(Z_PROBE_DELAY) && Z_PROBE_DELAY > 0
-        HAL::delayMilliseconds(Z_PROBE_DELAY);
-#endif
-        Motion1::stepsRemaining[Z_AXIS] = 0;
-        Motion1::endstopMode = EndstopMode::PROBING;
-        Motion1::moveByPrinter(tPos3, speed, false);
-        Motion1::waitForEndOfMoves();
-        Motion1::endstopMode = EndstopMode::DISABLED;
-
-        if (Motion1::stepsRemaining[Z_AXIS] < Z_CRASH_THRESHOLD_STEPS) {
-            Com::printErrorFLN(PSTR("Failed to trigger probe endstop! Bed crash?"));
-            Motion1::callAfterHomingOnSteppers();
-            return ILLEGAL_Z_PROBE;
-        }
-
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-        measurements[r] = z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
-#else
-        zr += z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
-#endif
-        // Go up to tPos2
+    if (repetitions > 1u) {
+        // We are now at z=0 do repetitions and assume correct them 100%
+        float cPos2[NUM_AXES], tPos2[NUM_AXES], tPos3[NUM_AXES];
         FOR_ALL_AXES(i) {
-            int32_t df = tPosSteps2[i] - tPosSteps3[i];
-            corSteps2[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
+            cPos2[i] = cPos[i];
+            tPos2[i] = cPos[i];
+            tPos3[i] = cPos[i];
         }
-        Motion1::moveRelativeBySteps(corSteps2);
-        Motion1::waitForEndOfMoves();
+        // Go up to start position for repeated tests
+        cPos2[Z_AXIS] = 0.0f;
         FOR_ALL_AXES(i) {
-            Motion1::currentPositionTransformed[i] = tPos2[i];
+            Motion1::currentPositionTransformed[i] = cPos2[i];
         }
         Motion1::updatePositionsFromCurrentTransformed();
         Motion2::setMotorPositionFromTransformed();
-    }
-#if defined(Z_PROBE_USE_MEDIAN) && Z_PROBE_USE_MEDIAN
-    // bubble sort the measurements
-    float tmp;
-    for (fast8_t i = 0; i < Z_PROBE_REPETITIONS - 1; i++) {         // n numbers require at most n-1 rounds of swapping
-        for (fast8_t j = 0; j < Z_PROBE_REPETITIONS - i - 1; j++) { //
-            if (measurements[j] > measurements[j + 1]) {            // out of order?
-                tmp = measurements[j];                              // swap them:
-                measurements[j] = measurements[j + 1];
-                measurements[j + 1] = tmp;
+        Motion1::endstopMode = EndstopMode::DISABLED;
+        tPos2[Z_AXIS] = Z_PROBE_SWITCHING_DISTANCE;
+        tPos3[Z_AXIS] = -1.0f;
+        int32_t cPosSteps2[NUM_AXES], tPosSteps2[NUM_AXES], tPosSteps3[NUM_AXES], corSteps2[NUM_AXES] = { 0 };
+        PrinterType::transform(cPos2, cPosSteps2);
+        PrinterType::transform(tPos2, tPosSteps2);
+        PrinterType::transform(tPos3, tPosSteps3);
+        tPos2[E_AXIS] = IGNORE_COORDINATE;
+        Motion1::moveByPrinter(tPos2, Motion1::maxFeedrate[X_AXIS], false);
+        Motion1::waitForEndOfMoves();
+#ifdef Z_PROBE_RUN_AFTER_EVERY_PROBE
+        GCode::executeFString(PSTR(Z_PROBE_RUN_AFTER_EVERY_PROBE));
+#endif
+
+        for (fast8_t r = 1; r < repetitions && !Printer::breakLongCommand; r++) {
+            // Go down
+#if defined(Z_PROBE_DELAY) && Z_PROBE_DELAY > 0
+            HAL::delayMilliseconds(Z_PROBE_DELAY);
+#endif
+            Motion1::stepsRemaining[Z_AXIS] = 0;
+            Motion1::endstopMode = EndstopMode::PROBING;
+            tPos3[E_AXIS] = IGNORE_COORDINATE;
+            Motion1::moveByPrinter(tPos3, speed, false);
+            Motion1::waitForEndOfMoves();
+            Motion1::endstopMode = EndstopMode::DISABLED;
+
+            if (Motion1::stepsRemaining[Z_AXIS] < Z_CRASH_THRESHOLD_STEPS) {
+                Com::printErrorFLN(PSTR("Failed to trigger probe endstop! Bed crash?"));
+                Motion1::callAfterHomingOnSteppers();
+                return ILLEGAL_Z_PROBE;
             }
+
+            if (useMedian) {
+                measurements[r] = z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0f) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
+            } else {
+                zr += z - 1.0f + (Z_PROBE_SWITCHING_DISTANCE + 1.0f) * ((fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps3[Z_AXIS] - tPosSteps2[Z_AXIS]));
+            }
+            // Go up to tPos2
+            FOR_ALL_AXES(i) {
+                int32_t df = tPosSteps2[i] - tPosSteps3[i];
+                corSteps2[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
+            }
+            Motion1::moveRelativeBySteps(corSteps2);
+            Motion1::waitForEndOfMoves();
+            FOR_ALL_AXES(i) {
+                Motion1::currentPositionTransformed[i] = tPos2[i];
+            }
+            Motion1::updatePositionsFromCurrentTransformed();
+            Motion2::setMotorPositionFromTransformed();
+        }
+        if (useMedian) {
+            //Com::printArrayFLN("measure: ", measurements, ARRAY_SIZE(measurements), 4);
+            float tmp;
+            for (fast8_t i = 0; i < repetitions - 1; i++) {         // n numbers require at most n-1 rounds of swapping
+                for (fast8_t j = 0; j < repetitions - i - 1; j++) { //
+                    if (measurements[j] > measurements[j + 1]) {    // out of order?
+                        tmp = measurements[j];                      // swap them:
+                        measurements[j] = measurements[j + 1];
+                        measurements[j + 1] = tmp;
+                    }
+                }
+            }
+            // Take median result
+            z = static_cast<float>(measurements[repetitions >> 1u]);
+        } else {
+            z = (z + zr) / static_cast<float>(repetitions);
+        }
+        // Fix last correction
+        FOR_ALL_AXES(i) {
+            corSteps[i] -= corSteps2[i];
         }
     }
-    // Take median result
-    z = static_cast<float>(measurements[Z_PROBE_REPETITIONS >> 1]);
-#else
-    z = (z + zr) / static_cast<float>(Z_PROBE_REPETITIONS);
-#endif
-    // Fix last correction
-    FOR_ALL_AXES(i) {
-        corSteps[i] -= corSteps2[i];
-    }
-#endif
-#if ENABLE_BUMP_CORRECTION
-    // if (Leveling::isDistortionEnabled()) {
-    // zCorr = Leveling::distortionAt(Motion1::currentPosition[X_AXIS], Motion1::currentPosition[Y_AXIS]);
-    // }
-#endif
     z += height;
-    z -= zCorr;
     /* DEBUG_MSG2_FAST("StartSteps", cPosSteps[Z_AXIS]);
     DEBUG_MSG2_FAST("EndSteps", tPosSteps[Z_AXIS]);
     DEBUG_MSG2_FAST("CorSteps", corSteps[Z_AXIS]);
@@ -670,7 +644,8 @@ float ZProbeHandler::runProbe() {
     }
     if (ZProbe->update()) {
         millis_t startTime = HAL::timeInMilliseconds();
-        while (ZProbe->update() && ((HAL::timeInMilliseconds() - startTime) < 200)) {
+        // wait up to 200ms to be sure signal stays
+        while (ZProbe->update() && ((HAL::timeInMilliseconds() - startTime) < 200ul)) {
             Commands::checkForPeriodicalActions(false);
         }
 
@@ -680,18 +655,10 @@ float ZProbeHandler::runProbe() {
             return ILLEGAL_Z_PROBE;
         }
     }
+    Motion1::waitForEndOfMoves();
     Com::printF(Com::tZProbe, z, 3);
     Com::printF(Com::tSpaceXColon, Motion1::currentPosition[X_AXIS]);
-#if ENABLE_BUMP_CORRECTION
-    if (Leveling::isDistortionEnabled()) {
-        Com::printF(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-        Com::printFLN(PSTR(" zCorr:"), zCorr, 3);
-    } else {
-        Com::printFLN(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-    }
-#else
     Com::printFLN(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-#endif
     Motion1::callAfterHomingOnSteppers();
     return z;
 }
@@ -790,6 +757,7 @@ bool ZProbeHandler::activate() {
     float cPos[NUM_AXES];
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, offsetX, offsetY, Z_PROBE_BORDER);
+    cPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     GCode::executeFString(Com::tZProbeStartScript);
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
@@ -808,7 +776,7 @@ bool ZProbeHandler::activate() {
         if (isAlarmOn()) {
             Motion1::setHardwareEndstopsAttached(false, ZProbe);
             // if BLTouch gives Alarm again, needle is blocked, stop printer
-            Motion1::waitForEndOfMoves();                                                                              // this avoids hard moves with very high feedrates and lost steps (where do they come from? only happens in case distortion correction is active.
+            Motion1::waitForEndOfMoves();                                                                                   // this avoids hard moves with very high feedrates and lost steps (where do they come from? only happens in case distortion correction is active.
             GCode::fatalError(PSTR("Z-Probe alarm triggered again before probing! Printer stopped to avoid a bed crash!")); // Z is raised to Z=30, probably by the fatalError
             return false;
         }
@@ -843,6 +811,7 @@ void ZProbeHandler::deactivate() {
     Motion1::copyCurrentOfficial(cPos);
     PrinterType::closestAllowedPositionWithNewXYOffset(cPos, tool->getOffsetX(), tool->getOffsetY(), Z_PROBE_BORDER);
     GCode::executeFString(Com::tZProbeEndScript);
+    cPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
     Motion1::setToolOffset(-tool->getOffsetX(), -tool->getOffsetY(), -tool->getOffsetZ());
     Motion1::moveByOfficial(cPos, Motion1::moveFeedrate[X_AXIS], false);
@@ -861,8 +830,7 @@ void ZProbeHandler::deactivate() {
 
 float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     Motion1::callBeforeHomingOnSteppers();
-    float zCorr = 0;
-    float measurements[constrain(repetitions, 1, 10)] = { 0.0f };
+    float measurements[constrain(repetitions, 1u, 10u)] = { 0.0f };
     if (ZProbe->update()) {
         Com::printErrorFLN(PSTR("z-probe triggered before starting probing."));
         Motion1::callAfterHomingOnSteppers();
@@ -870,9 +838,6 @@ float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     }
     if (Leveling::isDistortionEnabled()) {
         Com::printWarningFLN(PSTR("z-probe with distortion enabled can return unexpected results!"));
-        // Com::printErrorFLN(PSTR("z-probe stopped because bump correction is active. This will influence the result."));
-        // Motion1::callAfterHomingOnSteppers();
-        // return ILLEGAL_Z_PROBE;
     }
     bool wasActivated = activated;
     if (!activated) {
@@ -883,7 +848,7 @@ float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     EndstopMode oldMode = Motion1::endstopMode;
     Motion1::endstopMode = EndstopMode::PROBING;
     Motion1::waitForEndOfMoves(); // defined starting condition
-    Motion1::stopMask = 4;        // z trigger is finished
+    Motion1::stopMask = 4u;       // z trigger is finished
     float cPos[NUM_AXES], tPos[NUM_AXES];
     int32_t cPosSteps[NUM_AXES], tPosSteps[NUM_AXES], corSteps[NUM_AXES];
     Motion1::copyCurrentPrinter(cPos);
@@ -901,6 +866,7 @@ float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     HAL::delayMilliseconds(Z_PROBE_DELAY);
 #endif
     Motion1::stepsRemaining[Z_AXIS] = 0;
+    tPos[E_AXIS] = IGNORE_COORDINATE;
     Motion1::moveByPrinter(tPos, speed, false);
     Motion1::waitForEndOfMoves();
     Motion1::endstopMode = EndstopMode::DISABLED;
@@ -912,13 +878,13 @@ float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
     }
 
     float z = secureDistance * ((fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]) - Motion1::stepsRemaining[Z_AXIS]) / fabsf(tPosSteps[Z_AXIS] - cPosSteps[Z_AXIS]));
-    measurements[0] = z;
+    measurements[0u] = z;
     FOR_ALL_AXES(i) {
         int32_t df = cPosSteps[i] - tPosSteps[i];
         corSteps[i] = ((df > 0) ? 1 : ((df < 0) ? -1 : 0)) * (labs(df) - Motion1::stepsRemaining[i]);
     }
     float zr = 0.0f;
-    if (repetitions > 1) {
+    if (repetitions > 1u) {
         // We are now at z=0 do repetitions and assume correct them 100%
         float cPos2[NUM_AXES], tPos2[NUM_AXES], tPos3[NUM_AXES];
         FOR_ALL_AXES(i) {
@@ -997,6 +963,7 @@ float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
                     }
                 }
             }
+            // Take median result
             z = static_cast<float>(measurements[repetitions >> 1u]);
         } else {
             z = (z + zr) / static_cast<float>(repetitions);
@@ -1007,7 +974,6 @@ float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
         }
     }
     z += height;
-    z -= zCorr;
     /* DEBUG_MSG2_FAST("StartSteps", cPosSteps[Z_AXIS]);
     DEBUG_MSG2_FAST("EndSteps", tPosSteps[Z_AXIS]);
     DEBUG_MSG2_FAST("CorSteps", corSteps[Z_AXIS]);
@@ -1045,19 +1011,11 @@ float ZProbeHandler::runProbe(uint8_t repetitions, bool useMedian) {
             return ILLEGAL_Z_PROBE;
         }
     }
+    Motion1::waitForEndOfMoves();
     Com::printF(Com::tZProbe, z, 3);
     Com::printF(PSTR(" err:"), z - cPos[Z_AXIS], 3);
     Com::printF(Com::tSpaceXColon, Motion1::currentPosition[X_AXIS]);
-#if ENABLE_BUMP_CORRECTION
-    if (Leveling::isDistortionEnabled()) {
-        Com::printF(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-        Com::printFLN(PSTR(" zCorr:"), zCorr, 3);
-    } else {
-        Com::printFLN(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-    }
-#else
     Com::printFLN(Com::tSpaceYColon, Motion1::currentPosition[Y_AXIS]);
-#endif
     Motion1::callAfterHomingOnSteppers();
     return z;
 }

--- a/src/Repetier/src/drivers/zprobe.h
+++ b/src/Repetier/src/drivers/zprobe.h
@@ -4,7 +4,7 @@ class ZProbeHandler {
 public:
     static bool activate() { return true; }
     static void deactivate() { }
-    static float runProbe() { return 0; }
+    static float runProbe(uint8_t repetitions = Z_PROBE_REPETITIONS, bool useMedian = Z_PROBE_USE_MEDIAN) { return 0; }
     static bool probingPossible() { return false; }
     static float xOffset() { return 0; }
     static float yOffset() { return 0; }
@@ -57,7 +57,7 @@ class ZProbeHandler {
 public:
     static bool activate();
     static void deactivate();
-    static float runProbe();
+    static float runProbe(uint8_t repetitions = Z_PROBE_REPETITIONS, bool useMedian = Z_PROBE_USE_MEDIAN);
     static bool probingPossible();
     static void init();
     static void eepromHandle();
@@ -113,7 +113,7 @@ class ZProbeHandler {
 public:
     static bool activate();
     static void deactivate();
-    static float runProbe();
+    static float runProbe(uint8_t repetitions = Z_PROBE_REPETITIONS, bool useMedian = Z_PROBE_USE_MEDIAN);
     static bool probingPossible();
     static float xOffset();
     static float yOffset();
@@ -172,7 +172,7 @@ class ZProbeHandler {
 public:
     static bool activate();
     static void deactivate();
-    static float runProbe();
+    static float runProbe(uint8_t repetitions = Z_PROBE_REPETITIONS, bool useMedian = Z_PROBE_USE_MEDIAN);
     static bool probingPossible();
     static void init();
     static void eepromHandle();

--- a/src/Repetier/src/main.cpp
+++ b/src/Repetier/src/main.cpp
@@ -51,7 +51,12 @@ Implemented Codes
 - G30 P<0..3> - Single z-probe at current position P = 1 first measurement, P = 2 Last measurement P = 0 or 3 first and last measurement
 - G30 H<height> R<offset> Make probe define new Z and z offset (R) at trigger point assuming z-probe measured an object of H height.
 - G31 - Write signal of probe sensor
-- G32 S<0/1> P<gridsize> - Run LEVELING_METHOD on print bed. S = 1 Save to eeprom, P = Grid size points to probe if using LEVELING_METHOD_GRID. Min = 3, Max = MAX_GRID_SIZE, default if omitted = MAX_GRID_SIZE
+- G32 S<0/1> P<gridsize> R<repetitions> A<0/1> - Run LEVELING_METHOD on print bed. 
+        S = 1 Save to eeprom 
+        P = Grid size points to probe if using LEVELING_METHOD_GRID. 
+                Min = 3, Max = MAX_GRID_SIZE, default if omitted = MAX_GRID_SIZE
+        R = Probe repetitions (in-place), Z_PROBE_REPETITIONS if omitted.
+        A = Use median value of all probe repetition readings. Z_PROBE_USE_MEDIAN if omitted.
 - G33 R0 - Delete distortion map
 - G33 L0 - List distortion map
 - G33 X<xpos> Y<ypos> Z<newdistortioncorrection> - Set new distortion for nearest distortion point.

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -311,6 +311,7 @@ bool Leveling::measure(GCode* com) {
             pos[X_AXIS] = px - ZProbeHandler::xOffset();
             pos[Y_AXIS] = py - ZProbeHandler::yOffset();
             pos[Z_AXIS] = ZProbeHandler::optimumProbingHeight();
+            pos[E_AXIS] = IGNORE_COORDINATE;
             float bedPos[2] = { px, py };
             if (PrinterType::positionOnBed(bedPos) && PrinterType::positionAllowed(pos, pos[Z_AXIS])) {
                 if (ok) {
@@ -963,6 +964,9 @@ void Leveling::execute_G33(GCode* com) {
 bool Leveling::measure(GCode* com) {
     uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
     bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
+    if (repetitons < 1) {
+        repetitons = 1;
+    }
     Plane plane;
     PlaneBuilder builder;
     builder.reset();
@@ -1039,6 +1043,9 @@ bool Leveling::execute_G32(GCode* com) {
 bool Leveling::measure(GCode* com) {
     uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
     bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
+    if (repetitons < 1) {
+        repetitons = 1;
+    }
     Plane plane;
     PlaneBuilder builder;
     builder.reset();

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -241,15 +241,15 @@ bool Leveling::measure(GCode* com) {
     builder.reset();
     PrinterType::getBedRectangle(xMin, xMax, yMin, yMax);
     uint16_t gridSize = com->getP(MAX_GRID_SIZE);
-    uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
+    uint8_t repetitions = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
     bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
     // Sanity check for bad eeprom config
     // Todo: triggers a fatal error right now
     if (xMin == xMax || yMin == yMax || gridSize > MAX_GRID_SIZE || gridSize < 3) {
         return false;
     }
-    if (repetitons < 1) {
-        repetitons = 1;
+    if (repetitions < 1u) {
+        repetitions = 1u;
     }
     xMin += Z_PROBE_BORDER; // Safety border from config
     xMax -= Z_PROBE_BORDER;
@@ -317,7 +317,7 @@ bool Leveling::measure(GCode* com) {
                 if (ok) {
                     //Todo handle probe min bed temp (if disable heaters is on) over long durations
                     Motion1::moveByPrinter(pos, Motion1::moveFeedrate[X_AXIS], false);
-                    float h = ZProbeHandler::runProbe(repetitons, useMedian);
+                    float h = ZProbeHandler::runProbe(repetitions, useMedian);
                     ok &= h != ILLEGAL_Z_PROBE;
                     grid[xx][y] = h;
                     if (ok) {
@@ -962,10 +962,10 @@ void Leveling::execute_G33(GCode* com) {
 #if LEVELING_METHOD == LEVELING_METHOD_4_POINT_SYMMETRIC // 4 points
 
 bool Leveling::measure(GCode* com) {
-    uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
+    uint8_t repetitions = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
     bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
-    if (repetitons < 1) {
-        repetitons = 1;
+    if (repetitions < 1u) {
+        repetitions = 1u;
     }
     Plane plane;
     PlaneBuilder builder;
@@ -991,25 +991,25 @@ bool Leveling::measure(GCode* com) {
         if (!ZProbeHandler::activate()) {
             return false;
         }
-        h1 = ZProbeHandler::runProbe(repetitons, useMedian);
+        h1 = ZProbeHandler::runProbe(repetitions, useMedian);
         ok &= h1 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P2_X, L_P2_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h2 = ZProbeHandler::runProbe(repetitons, useMedian);
+        h2 = ZProbeHandler::runProbe(repetitions, useMedian);
         ok &= h2 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P3_X, L_P3_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h3 = ZProbeHandler::runProbe(repetitons, useMedian);
+        h3 = ZProbeHandler::runProbe(repetitions, useMedian);
         ok &= h3 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(x1Mirror, y1Mirror, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h4 = ZProbeHandler::runProbe(repetitons, useMedian);
+        h4 = ZProbeHandler::runProbe(repetitions, useMedian);
         ok &= h4 != ILLEGAL_Z_PROBE;
     }
     ZProbeHandler::deactivate();
@@ -1041,10 +1041,10 @@ bool Leveling::execute_G32(GCode* com) {
 #if LEVELING_METHOD == LEVELING_METHOD_3_POINTS // 3 points
 
 bool Leveling::measure(GCode* com) {
-    uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
+    uint8_t repetitions = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
     bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
-    if (repetitons < 1) {
-        repetitons = 1;
+    if (repetitions < 1u) {
+        repetitions = 1u;
     }
     Plane plane;
     PlaneBuilder builder;
@@ -1059,19 +1059,19 @@ bool Leveling::measure(GCode* com) {
         if (!ZProbeHandler::activate()) {
             return false;
         }
-        h1 = ZProbeHandler::runProbe(repetitons, useMedian);
+        h1 = ZProbeHandler::runProbe(repetitions, useMedian);
         ok &= h1 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P2_X, L_P2_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h2 = ZProbeHandler::runProbe(repetitons, useMedian);
+        h2 = ZProbeHandler::runProbe(repetitions, useMedian);
         ok &= h2 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P3_X, L_P3_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h3 = ZProbeHandler::runProbe(repetitons, useMedian);
+        h3 = ZProbeHandler::runProbe(repetitions, useMedian);
         ok &= h3 != ILLEGAL_Z_PROBE;
     }
     ZProbeHandler::deactivate();

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -232,7 +232,7 @@ void Leveling::setDistortionEnabled(bool newState) {
     Motion1::correctBumpOffset();
 }
 
-bool Leveling::measure(uint8_t gridSize) {
+bool Leveling::measure(GCode* com) {
     float pos[NUM_AXES];
     float tOffMinX, tOffMaxX, tOffMinY, tOffMaxY;
     Plane plane;
@@ -240,10 +240,16 @@ bool Leveling::measure(uint8_t gridSize) {
 
     builder.reset();
     PrinterType::getBedRectangle(xMin, xMax, yMin, yMax);
+    uint16_t gridSize = com->getP(MAX_GRID_SIZE);
+    uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
+    bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
     // Sanity check for bad eeprom config
     // Todo: triggers a fatal error right now
     if (xMin == xMax || yMin == yMax || gridSize > MAX_GRID_SIZE || gridSize < 3) {
         return false;
+    }
+    if (repetitons < 1) {
+        repetitons = 1;
     }
     xMin += Z_PROBE_BORDER; // Safety border from config
     xMax -= Z_PROBE_BORDER;
@@ -310,7 +316,7 @@ bool Leveling::measure(uint8_t gridSize) {
                 if (ok) {
                     //Todo handle probe min bed temp (if disable heaters is on) over long durations
                     Motion1::moveByPrinter(pos, Motion1::moveFeedrate[X_AXIS], false);
-                    float h = ZProbeHandler::runProbe();
+                    float h = ZProbeHandler::runProbe(repetitons, useMedian);
                     ok &= h != ILLEGAL_Z_PROBE;
                     grid[xx][y] = h;
                     if (ok) {
@@ -906,7 +912,7 @@ void Leveling::reportDistortionStatus() {
 #endif
 
 bool Leveling::execute_G32(GCode* com) {
-    bool ok = measure(com->hasP() ? com->P : MAX_GRID_SIZE);
+    bool ok = measure(com);
     if (com->hasS() && com->S > 0) {
         EEPROM::markChanged();
     }
@@ -954,7 +960,9 @@ void Leveling::execute_G33(GCode* com) {
 
 #if LEVELING_METHOD == LEVELING_METHOD_4_POINT_SYMMETRIC // 4 points
 
-bool Leveling::measure() {
+bool Leveling::measure(GCode* com) {
+    uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
+    bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
     Plane plane;
     PlaneBuilder builder;
     builder.reset();
@@ -979,25 +987,25 @@ bool Leveling::measure() {
         if (!ZProbeHandler::activate()) {
             return false;
         }
-        h1 = ZProbeHandler::runProbe();
+        h1 = ZProbeHandler::runProbe(repetitons, useMedian);
         ok &= h1 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P2_X, L_P2_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h2 = ZProbeHandler::runProbe();
+        h2 = ZProbeHandler::runProbe(repetitons, useMedian);
         ok &= h2 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P3_X, L_P3_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h3 = ZProbeHandler::runProbe();
+        h3 = ZProbeHandler::runProbe(repetitons, useMedian);
         ok &= h3 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(x1Mirror, y1Mirror, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h4 = ZProbeHandler::runProbe();
+        h4 = ZProbeHandler::runProbe(repetitons, useMedian);
         ok &= h4 != ILLEGAL_Z_PROBE;
     }
     ZProbeHandler::deactivate();
@@ -1017,7 +1025,7 @@ bool Leveling::measure() {
 }
 
 bool Leveling::execute_G32(GCode* com) {
-    bool ok = measure();
+    bool ok = measure(com);
     if (com->hasS() && com->S > 0) {
         EEPROM::markChanged();
     }
@@ -1028,7 +1036,9 @@ bool Leveling::execute_G32(GCode* com) {
 
 #if LEVELING_METHOD == LEVELING_METHOD_3_POINTS // 3 points
 
-bool Leveling::measure() {
+bool Leveling::measure(GCode* com) {
+    uint8_t repetitons = com->hasR() ? static_cast<uint8_t>(com->R) : Z_PROBE_REPETITIONS;
+    bool useMedian = com->hasA() ? static_cast<bool>(com->A) : Z_PROBE_USE_MEDIAN;
     Plane plane;
     PlaneBuilder builder;
     builder.reset();
@@ -1042,19 +1052,19 @@ bool Leveling::measure() {
         if (!ZProbeHandler::activate()) {
             return false;
         }
-        h1 = ZProbeHandler::runProbe();
+        h1 = ZProbeHandler::runProbe(repetitons, useMedian);
         ok &= h1 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P2_X, L_P2_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h2 = ZProbeHandler::runProbe();
+        h2 = ZProbeHandler::runProbe(repetitons, useMedian);
         ok &= h2 != ILLEGAL_Z_PROBE;
     }
     if (ok && !Printer::breakLongCommand) {
         Motion1::setTmpPositionXYZ(L_P3_X, L_P3_Y, ZProbeHandler::optimumProbingHeight());
         ok &= Motion1::moveByOfficial(Motion1::tmpPosition, Motion1::moveFeedrate[X_AXIS], false);
-        h3 = ZProbeHandler::runProbe();
+        h3 = ZProbeHandler::runProbe(repetitons, useMedian);
         ok &= h3 != ILLEGAL_Z_PROBE;
     }
     ZProbeHandler::deactivate();
@@ -1072,7 +1082,7 @@ bool Leveling::measure() {
 }
 
 bool Leveling::execute_G32(GCode* com) {
-    bool ok = measure();
+    bool ok = measure(com);
     if (com->hasS() && com->S > 0) {
         EEPROM::markChanged();
     }

--- a/src/Repetier/src/motion/LevelingMethod.h
+++ b/src/Repetier/src/motion/LevelingMethod.h
@@ -49,7 +49,7 @@ public:
     inline static float distortionAt(float xp, float yp) { return 0; }
     static void importBumpMatrix(char* filename) {}
     static void exportBumpMatrix(char* filename) {}
-    inline static bool measure() { return true; }
+    inline static bool measure(GCode* com) { return true; }
     inline static void init() {}
     inline static void handleEeprom() {}
     inline static void resetEeprom() {}
@@ -119,7 +119,7 @@ public:
     static void exportBumpMatrix(char* filename) {}
 #endif
     static void reportDistortionStatus();
-    static bool measure(uint8_t gridSize);
+    static bool measure(GCode* com);
     static void init();
     static void handleEeprom();
     static void resetEeprom();
@@ -137,7 +137,7 @@ public:
     inline static void setDistortionEnabled(bool newState) {}
     inline static bool isDistortionEnabled() { return false; }
     inline static float distortionAt(float xp, float yp) { return 0; }
-    static bool measure();
+    static bool measure(GCode* com);
     static void importBumpMatrix(char* filename) {}
     static void exportBumpMatrix(char* filename) {}
     inline static void init() {}
@@ -157,7 +157,7 @@ public:
     inline static void setDistortionEnabled(bool newState) {}
     inline static bool isDistortionEnabled() { return false; }
     inline static float distortionAt(float xp, float yp) { return 0; }
-    static bool measure();
+    static bool measure(GCode* com);
     static void importBumpMatrix(char* filename) {}
     static void exportBumpMatrix(char* filename) {}
     inline static void init() {}


### PR DESCRIPTION
Hi. I've added these two parameters to let us change the repetitions and use-median setting for probe runs at runtime as well. Works across all leveling types. 
Z_PROBE_REPETITIONS and Z_PROBE_USE_MEDIAN are now the default settings if the parameters are omitted.
