### PR TITLE
Skip old line numbers on boot

### DIFF
--- a/src/Repetier/src/communication/gcode.cpp
+++ b/src/Repetier/src/communication/gcode.cpp
@@ -248,6 +248,12 @@ void GCode::requestResend() {
   Check if result is plausible. If it is, an ok is send and the command is stored in queue.
   If not, a resend and ok is send.
 */
+
+// Reject previous linenumbers through serial in case we startup very fast.
+#ifndef REJECT_PREV_LINENUM_ON_BOOT
+#define REJECT_PREV_LINENUM_ON_BOOT 0
+#endif
+
 void GCode::checkAndPushCommand() {
     if (hasM()) {
         if (M == 110) // Reset line number
@@ -273,7 +279,10 @@ void GCode::checkAndPushCommand() {
     }
     if (hasN()) {
         if ((((GCodeSource::activeSource->lastLineNumber + 1) & 0xffff) != (actLineNumber & 0xffff))) {
-            if (static_cast<uint16_t>(GCodeSource::activeSource->lastLineNumber - actLineNumber) < 40) {
+            uint32_t dif = (actLineNumber > GCodeSource::activeSource->lastLineNumber)
+                ? (actLineNumber - GCodeSource::activeSource->lastLineNumber)
+                : (GCodeSource::activeSource->lastLineNumber - actLineNumber);
+            if (dif < 40) {
                 // we have seen that line already. So we assume it is a repeated resend and we ignore it
                 commandsReceivingWritePosition = 0;
                 Com::printFLN(Com::tSkip, actLineNumber);
@@ -284,7 +293,16 @@ void GCode::checkAndPushCommand() {
                     Com::printF(Com::tExpectedLine, GCodeSource::activeSource->lastLineNumber + 1);
                     Com::printFLN(Com::tGot, actLineNumber);
                 }
-                requestResend(); // Line missing, force resend
+#if REJECT_PREV_LINENUM_ON_BOOT
+                if (!GCodeSource::activeSource->lastLineNumber) {
+                    HAL::serialFlush();
+                    GCodeSource::activeSource->waitingForResend = sendAsBinary ? 30 : 14;
+                    Com::println();
+                    Com::printFLN(Com::tStart);
+                    Com::printFLN(Com::tOk);
+                } else
+#endif
+                    requestResend(); // Line missing, force resend
             } else {
                 --GCodeSource::activeSource->waitingForResend;
                 commandsReceivingWritePosition = 0;


### PR DESCRIPTION
This fixes a small problem where on reboots we'd try to ask-for-resend to linenum 1 when given a linenum from the previous connection.
Without this, firmware would replay a few previous (maybe dangerous) commands.


I also caught a very small bug in Repetier-Server:
The server seems to be sending a M105 right on connection start using an old linenum.

Mesg:12:51:05.071: Connection closed by os.
Mesg:12:51:06.072: Dtr: true Rts: true
Mesg:12:51:06.073: Connection started
Mesg:12:51:06.073: Dtr: true Rts: true
**Send:12:51:06.083: N18 M105**      _<--- bad M105 sent when connected using old linenum_
Recv:12:51:06.198: skip 18        _<--- Now only skipping using this fix._
Recv:12:51:06.198: Response while unconnected:ok
Recv:12:51:06.203: ok
Send:12:51:06.203: N0 M110 N0    _<--- Server sends my good first \<connectionCommands\> and resets linenum_

Here's a reboot during printing and what would happen **_before_** this fix:

Recv:13:05:43.570: Error:expected line 1 got 388
Recv:13:05:43.570: Resend:1
Mesg:13:05:43.570: Resend after 7436ms
Recv:13:05:43.581: skip 389
Recv:13:05:43.582: skip 390
Recv:13:05:43.582: skip 391
Recv:13:05:43.582: skip 392
Send:13:05:43.582: N1 N1 M110
Send:13:05:43.582: N2 G0 X43.279 Y55.164
Send:13:05:43.582: N3 G0 X24.476 Y36.36
continues to replay G1's, etc...

I've left the fix as a #if macro; REJECT_PREV_LINENUM_ON_BOOT, because I think this might break something by rejecting the line numbers in some cases. I also don't know what effects it has with octoprint atm.

I haven't been able to use the server's rescue system before this, actually. The resends would happen before the rescue commands. 

