### PR TITLE
Menus - Add Extr. Fine steps/mm menu & Misc Fixes

### DIFF
--- a/src/Repetier/src/drivers/heatManager.cpp
+++ b/src/Repetier/src/drivers/heatManager.cpp
@@ -10,7 +10,7 @@ void menuSetTemperature(GUIAction action, void* data) {
     HeatManager* hm = reinterpret_cast<HeatManager*>(data);
     float value = hm->getTargetTemperature();
     DRAW_FLOAT_P(PSTR("Target Temperature:"), Com::tUnitDegCelsius, value, 0);
-    if (GUI::handleFloatValueAction(action, value, hm->getMinTemperature(), hm->getMaxTemperature(), 1)) {
+    if (GUI::handleFloatValueAction(action, value, hm->getMinTemperature(), hm->getMaxTemperature(), (ENCODER_SPEED == 2) ? 5 : 1)) {
         hm->setTargetTemperature(value);
     }
 #endif
@@ -32,7 +32,7 @@ void menuHMMaxPWM(GUIAction action, void* data) {
 #if FEATURE_CONTROLLER != NO_CONTROLLER
     HeatManager* hm = reinterpret_cast<HeatManager*>(data);
     float value = hm->getMaxPWM();
-    DRAW_FLOAT_P(PSTR("Max. PWM:"), Com::tUnitDegCelsius, value, 0);
+    DRAW_FLOAT_P(PSTR("Max. PWM:"), Com::tUnitPWM, value, 0);
     if (GUI::handleFloatValueAction(action, value, 1, 255, 1)) {
         hm->setMaxPWM(static_cast<uint8_t>(value));
     }
@@ -344,7 +344,7 @@ void HeatManager::showBaseConfigMenu(GUIAction action) {
 #ifndef PREVENT_CHANGE_MAX_PWM
     GUI::menuLongP(action, PSTR("Max. PWM:"), maxPWM, menuHMMaxPWM, this, GUIPageType::FIXED_CONTENT);
 #endif
-    GUI::menuFloatP(action, PSTR("Decouple var.:"), decoupleVariance, 1, menuHMDecoupleVariance, this, GUIPageType::FIXED_CONTENT);
+    GUI::menuFloatP(action, PSTR("Decouple var.:"), decoupleVariance, 0, menuHMDecoupleVariance, this, GUIPageType::FIXED_CONTENT);
     GUI::menuLongP(action, PSTR("Decouple per.:"), decouplePeriod, menuHMDecouplePeriod, this, GUIPageType::FIXED_CONTENT);
     GUI::menuFloatP(action, PSTR("Hyster. temp.:"), hysteresisTemperature, 1, menuHMSetHysteresisTemperature, this, GUIPageType::FIXED_CONTENT);
     GUI::menuLongP(action, PSTR("Hyster. time:"), hysteresisTime, menuHMSetHysteresisTime, this, GUIPageType::FIXED_CONTENT);

--- a/src/Repetier/src/io/io_tools.h
+++ b/src/Repetier/src/io/io_tools.h
@@ -98,7 +98,7 @@
         if (stepper.overridesResolution()) { \
             stepper.menuConfig(action, data); \
         } else { \
-            GUI::menuFloatP(action, PSTR("Resolution:"), name.getResolution(), 2, menuExtruderStepsPerMM, &name, GUIPageType::FIXED_CONTENT); \
+            GUI::menuFloatP(action, PSTR("Resolution :"), name.getResolution(), 2, menuExtruderStepsPerMM, &name, GUIPageType::FIXED_CONTENT); \
         } \
         GUI::menuFloatP(action, PSTR("Max Speed  :"), name.getMaxSpeed(), 0, menuExtruderMaxSpeed, &name, GUIPageType::FIXED_CONTENT); \
         GUI::menuFloatP(action, PSTR("Max Accel. :"), name.getAcceleration(), 0, menuExtruderMaxAcceleration, &name, GUIPageType::FIXED_CONTENT); \

--- a/src/Repetier/src/tools/tools.cpp
+++ b/src/Repetier/src/tools/tools.cpp
@@ -140,7 +140,7 @@ void ToolChangeLink::deactivate(Tool* tool) {
 
 void __attribute__((weak)) menuToolOffsetXFine(GUIAction action, void* data) {
     Tool* ext = reinterpret_cast<Tool*>(data);
-    DRAW_FLOAT_P(PSTR("Offset X (0.01mm):"), Com::tUnitStepsPerMM, ext->getOffsetX(), 2);
+    DRAW_FLOAT_P(PSTR("Offset X (0.01mm):"), Com::tUnitMM, ext->getOffsetX(), 2);
     if (GUI::handleFloatValueAction(action, v, 0, 100000, 0.01)) {
         ext->setOffsetForAxis(X_AXIS, v);
         Tool::updateDerivedTools();
@@ -149,7 +149,7 @@ void __attribute__((weak)) menuToolOffsetXFine(GUIAction action, void* data) {
 
 void __attribute__((weak)) menuToolOffsetX(GUIAction action, void* data) {
     Tool* ext = reinterpret_cast<Tool*>(data);
-    DRAW_FLOAT_P(PSTR("Offset X (1mm):"), Com::tUnitStepsPerMM, ext->getOffsetX(), 2);
+    DRAW_FLOAT_P(PSTR("Offset X (1mm):"), Com::tUnitMM, ext->getOffsetX(), 2);
     if (action == GUIAction::CLICK) { // catch default action
         GUI::replace(menuToolOffsetXFine, data, GUIPageType::FIXED_CONTENT);
         return;
@@ -162,7 +162,7 @@ void __attribute__((weak)) menuToolOffsetX(GUIAction action, void* data) {
 
 void __attribute__((weak)) menuToolOffsetYFine(GUIAction action, void* data) {
     Tool* ext = reinterpret_cast<Tool*>(data);
-    DRAW_FLOAT_P(PSTR("Offset Y (0.01mm):"), Com::tUnitStepsPerMM, ext->getOffsetY(), 2);
+    DRAW_FLOAT_P(PSTR("Offset Y (0.01mm):"), Com::tUnitMM, ext->getOffsetY(), 2);
     if (GUI::handleFloatValueAction(action, v, 0, 100000, 0.01)) {
         ext->setOffsetForAxis(Y_AXIS, v);
         Tool::updateDerivedTools();
@@ -171,7 +171,7 @@ void __attribute__((weak)) menuToolOffsetYFine(GUIAction action, void* data) {
 
 void __attribute__((weak)) menuToolOffsetY(GUIAction action, void* data) {
     Tool* ext = reinterpret_cast<Tool*>(data);
-    DRAW_FLOAT_P(PSTR("Offset Y (1mm):"), Com::tUnitStepsPerMM, ext->getOffsetY(), 2);
+    DRAW_FLOAT_P(PSTR("Offset Y (1mm):"), Com::tUnitMM, ext->getOffsetY(), 2);
     if (action == GUIAction::CLICK) { // catch default action
         GUI::replace(menuToolOffsetYFine, data, GUIPageType::FIXED_CONTENT);
         return;
@@ -184,7 +184,7 @@ void __attribute__((weak)) menuToolOffsetY(GUIAction action, void* data) {
 
 void __attribute__((weak)) menuToolOffsetZFine(GUIAction action, void* data) {
     Tool* ext = reinterpret_cast<Tool*>(data);
-    DRAW_FLOAT_P(PSTR("Offset Z (0.01mm):"), Com::tUnitStepsPerMM, ext->getOffsetZ(), 2);
+    DRAW_FLOAT_P(PSTR("Offset Z (0.01mm):"), Com::tUnitMM, ext->getOffsetZ(), 2);
     if (GUI::handleFloatValueAction(action, v, 0, 100000, 0.01)) {
         ext->setOffsetForAxis(Z_AXIS, v);
         Tool::updateDerivedTools();
@@ -193,7 +193,7 @@ void __attribute__((weak)) menuToolOffsetZFine(GUIAction action, void* data) {
 
 void __attribute__((weak)) menuToolOffsetZ(GUIAction action, void* data) {
     Tool* ext = reinterpret_cast<Tool*>(data);
-    DRAW_FLOAT_P(PSTR("Offset Z (1mm):"), Com::tUnitStepsPerMM, ext->getOffsetZ(), 2);
+    DRAW_FLOAT_P(PSTR("Offset Z (1mm):"), Com::tUnitMM, ext->getOffsetZ(), 2);
     if (action == GUIAction::CLICK) { // catch default action
         GUI::replace(menuToolOffsetZFine, data, GUIPageType::FIXED_CONTENT);
         return;
@@ -204,10 +204,23 @@ void __attribute__((weak)) menuToolOffsetZ(GUIAction action, void* data) {
     }
 }
 
+void __attribute__((weak)) menuExtruderStepsPerMMFine(GUIAction action, void* data) {
+    ToolExtruder* ext = reinterpret_cast<ToolExtruder*>(data);
+    DRAW_FLOAT_P(PSTR("Resolution Fine:"), Com::tUnitStepsPerMM, ext->getResolution(), 2);
+    if (GUI::handleFloatValueAction(action, v, 0.0f, 100000.0f, 0.01f)) {
+        ext->setResolution(v);
+        Tool::updateDerivedTools();
+    }
+}
+
 void __attribute__((weak)) menuExtruderStepsPerMM(GUIAction action, void* data) {
     ToolExtruder* ext = reinterpret_cast<ToolExtruder*>(data);
-    DRAW_FLOAT_P(PSTR("Resolution:"), Com::tUnitStepsPerMM, ext->getResolution(), 2);
-    if (GUI::handleFloatValueAction(action, v, 0, 100000, 0.1)) {
+    DRAW_FLOAT_P(PSTR("Resolution Coarse:"), Com::tUnitStepsPerMM, ext->getResolution(), 2);
+    if (action == GUIAction::CLICK) { // catch default action
+        GUI::replace(menuExtruderStepsPerMMFine, data, GUIPageType::FIXED_CONTENT);
+        return;
+    }
+    if (GUI::handleFloatValueAction(action, v, 0.0f, 100000.0f, 1.0f)) {
         ext->setResolution(v);
         Tool::updateDerivedTools();
     }
@@ -233,7 +246,7 @@ void __attribute__((weak)) menuExtruderMaxAcceleration(GUIAction action, void* d
 
 void __attribute__((weak)) menuExtruderMaxYank(GUIAction action, void* data) {
     ToolExtruder* ext = reinterpret_cast<ToolExtruder*>(data);
-    DRAW_FLOAT_P(PSTR("Max. Jerk"), Com::tUnitMMPS, ext->getMaxYank(), 0);
+    DRAW_FLOAT_P(PSTR("Max. Jerk"), Com::tUnitMMPS, ext->getMaxYank(), 1);
     if (GUI::handleFloatValueAction(action, v, 0.1, 100, 0.1)) {
         ext->setMaxYank(v);
         Tool::updateDerivedTools();


### PR DESCRIPTION
- Added Coarse/Fine menus for the extruder resolution menu to match the axis controls.
- The target temp increment feels far too slow on encoder speed 2, i've added a small check to increase it to 5 when on speed 2.
    This is the only control so far that I felt needed this though, everything else seem fine.

- A few incorrect unit display fixes (MaxPWM, Extr. offsets, etc)