### PR TITLE
Fix missing bed/chamber tune controls

### DIFF
--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -651,6 +651,21 @@ void __attribute__((weak)) menuTune(GUIAction action, void* data) {
 #undef IO_TARGET
 #define IO_TARGET IO_TARGET_GUI_TUNE
 #include "../io/redefine.h"
+    // Bed and chamber have no own entry so add it and point to temperature manager
+    for (ufast8_t i = 0; i < NUM_HEATED_BEDS; i++) {
+#if NUM_HEATED_BEDS > 1
+        GUI::menuLongP(action, PSTR("Bed "), i + 1, menuTempControl, heatedBeds[i], GUIPageType::MENU);
+#else
+        GUI::menuSelectableP(action, PSTR("Bed "), menuTempControl, heatedBeds[i], GUIPageType::MENU);
+#endif
+    }
+    for (ufast8_t i = 0; i < NUM_HEATED_CHAMBERS; i++) {
+#if NUM_HEATED_CHAMBERS > 1
+        GUI::menuLongP(action, PSTR("Chamber "), i + 1, menuTempControl, heatedChambers[i], GUIPageType::MENU);
+#else
+        GUI::menuSelectableP(action, PSTR("Chamber"), menuTempControl, heatedChambers[i], GUIPageType::MENU);
+#endif
+    }
     GUI::menuEnd(action);
 }
 


### PR DESCRIPTION
Just noticed controlling the temps on these two were missing while printing. 

I think it may also be a good idea to remove the home/move options from the tune menu? 
Or hide them unless paused, maybe.
