### PR TITLE
GUI - SD Menu scroll bar

### DIFF
--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -1208,6 +1208,11 @@ void GUI::showValue(char* text, PGM_P unit, char* value) {
     printRowCentered(3, GUI::buf);
 }
 
+// No scrollbars for the 20x4's 
+void GUI::showScrollbar(GUIAction& action) {
+}
+void GUI::showScrollbar(GUIAction& action, float percent, uint16_t min, uint16_t max) {
+}
 //extern void __attribute__((weak)) startScreen(GUIAction action, void* data);
 //extern void __attribute__((weak)) printProgress(GUIAction action, void* data);
 // extern void __attribute__((weak)) mainMenu(GUIAction action, void* data);

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -705,6 +705,39 @@ void GUI::showValue(char* text, PGM_P unit, char* value) {
     lcd.setDrawColor(1);
 }
 
+void GUI::showScrollbar(GUIAction& action, float percent, uint16_t min, uint16_t max) {
+    if (action == GUIAction::DRAW) {
+        if (min == max) {
+            return;
+        }
+        static float lastPos = 0.0f;
+        static millis_t lastUpdate = 0ul;
+        uint16_t pxSize = static_cast<uint16_t>((static_cast<float>(min) / static_cast<float>(max)) * 35.0f);
+        if (pxSize < 5.0f) {
+            pxSize = 5.0f;
+        }
+        uint16_t pxPos = static_cast<uint16_t>(percent * (63.0f - pxSize - 10.0f));
+        if (percent != lastPos) {
+            lastUpdate = HAL::timeInMilliseconds();
+        } else if ((HAL::timeInMilliseconds() - lastUpdate) > 750ul) {
+            return;
+        }
+        lastPos = percent;
+        lcd.setDrawColor(0u);
+        lcd.drawBox(128u - 8u + 3u, 9u, 8u, 64u - 9u);
+        lcd.setDrawColor(1u);
+        lcd.drawVLine(128u - 9u + 3u, 9u, 64u - 9u);
+        lcd.drawBox(128u - 7u + 3u, 10u + pxPos, 3u, pxSize);
+    }
+}
+void GUI::showScrollbar(GUIAction& action) {
+    if (action == GUIAction::DRAW) {
+        if (length[level] > 5) {
+            float percent = static_cast<float>(topRow[level]) / static_cast<float>(length[level] - 5);
+            showScrollbar(action, percent, 5u, static_cast<uint16_t>(length[level]));
+        }
+    }
+}
 void __attribute__((weak)) probeProgress(GUIAction action, void* data) {
 
     if (action == GUIAction::DRAW) {

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -227,6 +227,9 @@ public:
     static void menuSelectable(GUIAction& action, char* text, GuiCallback cb, void* cData, GUIPageType tp);
     static void menuBack(GUIAction& action);
 
+    static void showScrollbar(GUIAction& action);
+    static void showScrollbar(GUIAction& action, float percent, uint16_t min, uint16_t max);
+
     // Value modifyer display
 
     // Draw display with content for a value given as string


### PR DESCRIPTION
Forgot to upload this tiny gui addition to help with large folders. Only shows up for U8G2's.
A thin simplish scrollbar appears at the right of the screen while the rows change. 
It disappears quickly after we stop moving to avoid blocking any important text. 

Made for the SD menus, but coincidentally works for all/any menus as well. I only added them to the sd menu. 

GUI::showScrollbar(GUIAction& action) <- auto calculates the bar based on top row, current row, length etc. 
Just drop before a menuEnd and the bar should appear if there's enough items on the screen.

GUI::showScrollbar(GUIAction& action, float percent, uint16_t min, uint16_t max) <- allows manual control