### PR TITLE
Steppers - Fix STEPPER_OBSERVEABLE TMC driver eeprom

### DIFF
--- a/src/Repetier/src/drivers/stepper.cpp
+++ b/src/Repetier/src/drivers/stepper.cpp
@@ -17,7 +17,8 @@ static_assert(numMotorNames == NUM_MOTORS, "NUM_MOTORS not defined correctly");
 
 int StepperDriverBase::motorIndex() {
     for (fast8_t i = 0; i < NUM_MOTORS; i++) {
-        if (this == Motion1::drivers[i]) {
+        if (this == Motion1::drivers[i]
+            || (this->parent == Motion1::drivers[i])) {
             return i;
         }
     }
@@ -609,8 +610,7 @@ void TMCStepper5160Driver<stepCls, dirCls, enableCls, fclk>::afterHoming() {
 template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
 void TMCStepper5160Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& com) {
     switch (com.M) {
-    case 122: // print debug informations
-    {
+    case 122: { // print debug informations
         Com::println();
         printMotorNumberAndName();
         reportTMC5160(driver, this, com.hasD() ? static_cast<int>(com.D) : 0);
@@ -734,14 +734,14 @@ void TMCStepper2208Driver<stepCls, dirCls, enableCls, fclk>::init() {
     disable();
     driver->begin();
 
-    TMC2208_n::GCONF_t gconf { 0 };
+    TMC2208_n::GCONF_t gconf = { 0 };
     gconf.pdn_disable = true;      // Use UART
     gconf.mstep_reg_select = true; // Select microsteps with UART
     gconf.i_scale_analog = false;
     gconf.en_spreadcycle = !stealthChop;
     driver->GCONF(gconf.sr);
 
-    TMC2208_n::CHOPCONF_t chopconf { 0 };
+    TMC2208_n::CHOPCONF_t chopconf = { 0 };
     chopconf.tbl = 1;
     chopconf.toff = tmcChopperTiming.toff;
     chopconf.intpol = TMC_INTERPOLATE;
@@ -870,8 +870,7 @@ void TMCStepper2208Driver<stepCls, dirCls, enableCls, fclk>::afterHoming() {
 template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
 void TMCStepper2208Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& com) {
     switch (com.M) {
-    case 122: // print debug informations
-    {
+    case 122: { // print debug informations
         Com::println();
         printMotorNumberAndName();
         reportTMC2208(driver, this, com.hasD() ? static_cast<int>(com.D) : 0);
@@ -1152,8 +1151,7 @@ void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::afterHoming() {
 template <class stepCls, class dirCls, class enableCls, uint32_t fclk>
 void TMCStepper2209Driver<stepCls, dirCls, enableCls, fclk>::handleMCode(GCode& com) {
     switch (com.M) {
-    case 122: // print debug informations
-    {
+    case 122: { // print debug informations
         Com::println();
         printMotorNumberAndName();
         reportTMC2209(driver, this, com.hasD() ? static_cast<int>(com.D) : 0);

--- a/src/Repetier/src/drivers/stepper.h
+++ b/src/Repetier/src/drivers/stepper.h
@@ -10,6 +10,7 @@ enum class GUIAction;
 
 class StepperDriverBase {
 protected:
+    StepperDriverBase* parent;
     EndstopDriver* minEndstop;
     EndstopDriver* maxEndstop;
     bool direction;
@@ -18,12 +19,14 @@ protected:
 
 public:
     StepperDriverBase(EndstopDriver* minES, EndstopDriver* maxES)
-        : minEndstop(minES)
+        : parent(nullptr)
+        , minEndstop(minES)
         , maxEndstop(maxES)
         , direction(true)
         , axisBit(8)
         , axis(E_AXIS) { }
     virtual ~StepperDriverBase() { }
+    inline void setParent(StepperDriverBase* ptr) { parent = ptr; }
     inline EndstopDriver* getMinEndstop() { return minEndstop; }
     inline EndstopDriver* getMaxEndstop() { return maxEndstop; }
     inline bool updateEndstop() {
@@ -139,7 +142,10 @@ public:
     uint32_t position;
     ObservableStepperDriver(driver* _stepper)
         : StepperDriverBase(_stepper->getMinEndstop(), _stepper->getMaxEndstop())
-        , stepper(_stepper) { position = 0; }
+        , stepper(_stepper) {
+        stepper->setParent(this);
+        position = 0;
+    }
     virtual ~ObservableStepperDriver() { }
     inline EndstopDriver* getMinEndstop() { return minEndstop; }
     inline EndstopDriver* getMaxEndstop() { return maxEndstop; }
@@ -184,6 +190,9 @@ public:
     // Configuration in GUI
     virtual void menuConfig(GUIAction action, void* data) {
         stepper->menuConfig(action, data);
+    }
+    virtual void eepromHandle() final {
+        stepper->eepromHandle();
     }
 };
 


### PR DESCRIPTION
Are we still using this module for jam detection? I remember it was in the default IO configuration. Looks like the samplesystems changed a bit from last I looked.

Stepper Observable has a small bug where it'd prevent the tmc eeprom from showing if we added it's class to the motor list instead of the driver itself. 

This adds the driver's missing eepromHandler call, and adds a parent pointer check in motorIndex to find the correct motor list index.
