### PR TITLE
GUI - waitScreen newline & Write file show speed/written

### DIFF
--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -1547,9 +1547,18 @@ void waitScreen(GUIAction action, void* data) {
     if (action == GUIAction::DRAW) {
         char* text = static_cast<char*>(data);
 
-        printRowCentered(0, text);
-        GUI::bufClear();
-        printRow(1, GUI::buf);
+        char* newLine = strchr(text, '\n');
+        if (newLine) {
+            *newLine = '\0';
+            printRowCentered(0, text);
+            *newLine = '\n';
+            printRowCentered(1, newLine + 1);
+            GUI::bufClear();
+        } else {
+            printRowCentered(0, text);
+            GUI::bufClear();
+            printRow(1, GUI::buf);
+        }
         printRow(2, GUI::buf);
         fast8_t len = refresh_counter % UI_COLS;
         for (fast8_t i = 0; i < len; i++) {
@@ -1561,13 +1570,20 @@ void waitScreen(GUIAction action, void* data) {
 
 void waitScreenP(GUIAction action, void* data) {
     if (action == GUIAction::DRAW) {
-        char* text = static_cast<char*>(data);
-
         GUI::bufClear();
         GUI::bufAddStringP((const char*)data);
-        printRowCentered(0, GUI::buf);
-        GUI::bufClear();
-        printRow(1, GUI::buf);
+        char* newLine = strchr(GUI::buf, '\n');
+        if (newLine) {
+            *newLine = '\0';
+            printRowCentered(0, GUI::buf);
+            *newLine = '\n';
+            printRowCentered(1, newLine + 1);
+            GUI::bufClear();
+        } else {
+            printRowCentered(0, GUI::buf);
+            GUI::bufClear();
+            printRow(1, GUI::buf);
+        }
         printRow(2, GUI::buf);
         fast8_t len = refresh_counter % UI_COLS;
         for (fast8_t i = 0; i < len; i++) {

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -1258,13 +1258,23 @@ void waitScreen(GUIAction action, void* data) {
             refresh_counter = 8;
             break;
         }
-        int len = strlen(static_cast<char*>(data));
+        char* str = static_cast<char*>(data); 
+        int len = strlen(str);
         if (len <= 10) {
             lcd.setFont(u8g2_font_10x20_mf);
-            lcd.drawUTF8(73 - len * 5, SPIN_CENTER_Y + 7, static_cast<char*>(data));
-        } else {
+            lcd.drawUTF8(73 - len * 5, SPIN_CENTER_Y + 7, str);
+        } else { 
+            char* newLine = strchr(str, '\n');
             lcd.setFont(u8g2_font_6x10_mf);
-            lcd.drawUTF8(73 - len * 3, SPIN_CENTER_Y + 3, static_cast<char*>(data));
+            if (newLine) { 
+                *newLine = '\0';
+                uint8_t newLineLen = (newLine - str);
+                lcd.drawUTF8(73 - newLineLen * 3, (SPIN_CENTER_Y + 3) - 5, str);
+                *newLine = '\n';
+                lcd.drawUTF8(73 - (len - newLineLen) * 3, (SPIN_CENTER_Y + 3) + 5, str + newLineLen + 1);
+            } else {
+                lcd.drawUTF8(73 - len * 3, SPIN_CENTER_Y + 3, str); 
+            }
         }
     }
 }
@@ -1303,14 +1313,23 @@ void waitScreenP(GUIAction action, void* data) {
             break;
         }
         GUI::bufClear();
-        GUI::bufAddStringP((const char*)data);
-        int len = strlen(static_cast<char*>(GUI::buf));
+        GUI::bufAddStringP(static_cast<const char*>(data));
+        int len = GUI::bufPos;
         if (len <= 10) {
             lcd.setFont(u8g2_font_10x20_mf);
             lcd.drawUTF8(73 - len * 5, SPIN_CENTER_Y + 7, static_cast<char*>(GUI::buf));
         } else {
+            char* newLine = strchr(GUI::buf, '\n');
             lcd.setFont(u8g2_font_6x10_mf);
-            lcd.drawUTF8(73 - len * 3, SPIN_CENTER_Y + 3, static_cast<char*>(GUI::buf));
+            if (newLine) { 
+                *newLine = '\0';
+                uint8_t newLineLen = (newLine - GUI::buf);
+                lcd.drawUTF8(73 - newLineLen * 3, (SPIN_CENTER_Y + 3) - 5, GUI::buf);
+                *newLine = '\n';
+                lcd.drawUTF8(73 - (len - newLineLen) * 3, (SPIN_CENTER_Y + 3) + 5, GUI::buf + newLineLen + 1);
+            } else {
+                lcd.drawUTF8(73 - len * 3, SPIN_CENTER_Y + 3, GUI::buf); 
+            }
         }
     }
 }

--- a/src/Repetier/src/sdcard/SDCard.cpp
+++ b/src/Repetier/src/sdcard/SDCard.cpp
@@ -211,7 +211,7 @@ void SDCard::unmount(const bool manual) {
         return;
     }
     mountRetries = 0u;
-    //if (state != SDState::SD_HAS_ERROR) {
+
     if (!volumeLabel[0u]) {
         UI_STATUS_UPD("SD Card removed.");
     } else {
@@ -219,7 +219,6 @@ void SDCard::unmount(const bool manual) {
         UI_STATUS_UPD_RAM(GUI::tmpString);
     }
     Com::printFLN(PSTR("SD card removed")); // Needed for hosts
-    //}
 
 #if defined(EEPROM_AVAILABLE) && EEPROM_AVAILABLE == EEPROM_SDCARD
     eepromFile.close();
@@ -545,8 +544,7 @@ void SDCard::printFullyStopped() {
 }
 
 void SDCard::writeCommand(GCode* code) {
-    lastWriteTimeMS = HAL::timeInMilliseconds(); // Reset the timeout
-    unsigned int sum1 = 0u, sum2 = 0u;           // for fletcher-16 checksum
+    unsigned int sum1 = 0u, sum2 = 0u; // for fletcher-16 checksum
     uint8_t buf[100u];
     uint8_t p = 2u;
     selectedFile.clearWriteError();
@@ -696,6 +694,23 @@ void SDCard::writeCommand(GCode* code) {
         Com::printErrorFLN(Com::tAPIDFinished);
     } else {
         writtenBytes += selectedFile.write(buf, p);
+
+        if ((HAL::timeInMilliseconds() - lastWriteTimeMS) > 1000ul && writtenBytes) {
+            if (GUI::statusLevel == GUIStatusLevel::BUSY) {
+                float kB = writtenBytes / 1000.0f;
+                GUI::flashToStringFloat(GUI::status, PSTR("Received @ B"), kB > 1000.0f ? kB / 1000.0f : kB, 1);
+                size_t len = strlen(GUI::status); 
+                GUI::status[len - 2] = kB > 1000.0f ? 'M' : 'k';
+                static float lastKBytes = 0.0f;
+                if (!lastWriteTimeMS) {
+                    lastKBytes = 0.0f;
+                }
+                GUI::flashToStringFloat(GUI::tmpString, PSTR("\n @kB/s"), kB - lastKBytes, 1);
+                lastKBytes = kB;
+                strncat(GUI::status, GUI::tmpString, sizeof(GUI::status) - len);
+            }
+            lastWriteTimeMS = HAL::timeInMilliseconds();
+        }
     }
     if (selectedFile.getWriteError()) {
         Com::printFLN(Com::tErrorWritingToFile);
@@ -799,15 +814,10 @@ void SDCard::startWrite(const char* filename) {
     if (!selectedFile.open(filename, O_CREAT | O_APPEND | O_WRONLY | O_TRUNC)) {
         Com::printFLN(Com::tOpenFailedFile, filename);
     } else {
-#if defined(__AVR__)
-        selectedFile.preAllocate(1024ul * 2ul); // 2kb for AVR?
-#else
-        selectedFile.preAllocate((1024ul * 4ul) * 2ul);
-#endif
         writtenBytes = 0ul;
-        GUI::setStatusP(PSTR("Receiving file..."), GUIStatusLevel::INFO);
+        GUI::setStatusP(PSTR("Receiving file..."), GUIStatusLevel::BUSY);
         Com::printFLN(Com::tWritingToFile, filename);
-        lastWriteTimeMS = HAL::timeInMilliseconds();
+        lastWriteTimeMS = 0ul;
         state = SDState::SD_WRITING;
     }
 }


### PR DESCRIPTION
I added the ability for us to pass a newline character to waitScreen and for it to split the text onto the next row. Works with PSTR too. 
SD file writing now displays a busy status that shows the current written bytes and the current write speed. 
I tried keeping it all fairly lightweight.