### PR TITLE
ZProbe - Reheat bed between grid probes if paused

### DIFF
--- a/src/Repetier/src/Configuration.h
+++ b/src/Repetier/src/Configuration.h
@@ -72,6 +72,7 @@
 #define Z_PROBE_BORDER 2        // Safety border to ensure position is allowed
 #define Z_PROBE_TEMPERATURE 170 // Temperature for type 2
 
+
 // 0 = Cartesian, 1 = CoreXYZ, 2 = delta, 3 = Dual X-Axis
 #define PRINTER_TYPE 0
 // steps to include as babysteps per 1/BLOCK_FREQUENCY seconds. Must be lower then STEPPER_FREQUENCY/BLOCK_FREQUENCY and be low enough to not loose steps.
@@ -408,6 +409,8 @@ CONFIG_VARIABLE_EQ(EndstopDriver, *ZProbe, &endstopZMin)
 #define Z_PROBE_RUN_AFTER_EVERY_PROBE ""
 #define Z_PROBE_REQUIRES_HEATING 1
 #define Z_PROBE_MIN_TEMPERATURE 150
+#define Z_PROBE_PAUSE_HEATERS 0         // Pause all heaters when probing to reduce EMI artifacts
+#define Z_PROBE_PAUSE_BED_REHEAT_TEMP 5 // Stop and reheat the bed if we leave the target temp by this much.
 
 // How to correct rotated beds
 // 0 = Software side by rotating coordinates

--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -398,6 +398,10 @@ extern ServoInterface* servos[];
 #define Z_PROBE_PAUSE_HEATERS 0
 #endif
 
+#ifndef Z_PROBE_PAUSE_BED_REHEAT_TEMP
+#define Z_PROBE_PAUSE_BED_REHEAT_TEMP 5
+#endif
+
 #ifndef Z_PROBE_BLTOUCH_DEPLOY_DELAY
 #define Z_PROBE_BLTOUCH_DEPLOY_DELAY 1000
 #endif
@@ -650,7 +654,7 @@ public:
     sd_file_t selectedFile;
     sd_fsys_t fileSystem;
     SDState state;
- 
+
     char volumeLabel[21];
 
     bool scheduledPause;

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -316,15 +316,17 @@ bool Leveling::measure(GCode* com) {
             float bedPos[2] = { px, py };
             if (PrinterType::positionOnBed(bedPos) && PrinterType::positionAllowed(pos, pos[Z_AXIS])) {
                 if (ok) {
-#if NUM_HEATED_BEDS
-                    if (ZProbeHandler::getHeaterPause() && heatedBeds[0u]->isPaused()) {
-                        if (fabs(heatedBeds[0u]->getCurrentTemperature() - heatedBeds[0u]->getTargetTemperature()) > 5.0f) {
+#if NUM_HEATED_BEDS && Z_PROBE_PAUSE_BED_REHEAT_TEMP
+                    if (x && ZProbeHandler::getHeaterPause() && heatedBeds[0u]->isPaused()) {
+                        if (fabs(heatedBeds[0u]->getCurrentTemperature() - heatedBeds[0u]->getTargetTemperature()) > Z_PROBE_PAUSE_BED_REHEAT_TEMP) {
                             heatedBeds[0u]->unpause();
                             Motion1::waitForEndOfMoves();
                             GUI::setStatusP(PSTR("Reheating bed..."), GUIStatusLevel::REGULAR);
+                            pos[Z_AXIS] += 3.0f;
                             Motion1::moveByPrinter(pos, Motion1::moveFeedrate[X_AXIS], false);
                             Motion1::waitForEndOfMoves();
                             heatedBeds[0u]->waitForTargetTemperature();
+                            pos[Z_AXIS] -= 3.0f;
                             GUI::clearStatus();
                             heatedBeds[0u]->pause();
                             HAL::delayMilliseconds(150ul);

--- a/src/Repetier/src/motion/LevelingMethod.cpp
+++ b/src/Repetier/src/motion/LevelingMethod.cpp
@@ -310,8 +310,25 @@ bool Leveling::measure(GCode* com) {
             py = yMin + (y * tempDy);
             pos[X_AXIS] = px - ZProbeHandler::xOffset();
             pos[Y_AXIS] = py - ZProbeHandler::yOffset();
-            pos[Z_AXIS] = ZProbeHandler::optimumProbingHeight();
             pos[E_AXIS] = IGNORE_COORDINATE;
+
+#if NUM_HEATED_BEDS
+            if (ZProbeHandler::getHeaterPause() && heatedBeds[0u]->isPaused()) {
+                if (fabs(heatedBeds[0u]->getCurrentTemperature() - heatedBeds[0u]->getTargetTemperature()) > 5.0f) {
+                    heatedBeds[0u]->unpause();
+                    Motion1::waitForEndOfMoves();
+                    GUI::setStatusP(PSTR("Reheating bed..."), GUIStatusLevel::REGULAR);
+                    pos[Z_AXIS] = ZProbeHandler::optimumProbingHeight() + 5.0f;
+                    Motion1::moveByPrinter(pos, Motion1::moveFeedrate[X_AXIS], false);
+                    Motion1::waitForEndOfMoves();
+                    heatedBeds[0u]->waitForTargetTemperature();
+                    GUI::clearStatus();
+                    heatedBeds[0u]->pause();
+                    HAL::delayMilliseconds(150ul);
+                }
+            }
+#endif
+            pos[Z_AXIS] = ZProbeHandler::optimumProbingHeight();
             float bedPos[2] = { px, py };
             if (PrinterType::positionOnBed(bedPos) && PrinterType::positionAllowed(pos, pos[Z_AXIS])) {
                 if (ok) {


### PR DESCRIPTION
During long probes our beds can lose a bit of temperature if we're pausing all heaters. 
I've added this small feature to halt the probing and reheat if we stray too far from the target bed temp. 
By default it'll do it if we differ by more than 5c. It'll show a status message when this occurs.

I've added an adjustable macro for it incase the user wants it off, or at different threshold.
Z_PROBE_PAUSE_BED_REHEAT_TEMP.
