### PR TITLE
SD Card - Bug fixes / Eeprom corruption fix

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -642,16 +642,18 @@ void Printer::setup() {
     // Extruder::initExtruder();
     // sets auto leveling in eeprom init
     GUI::init();
-    //Commands::printCurrentPosition();
 
+#if SDSUPPORT // Try mounting the SDCard first in case it has an eeprom file.
+    sd.mount(true);
+#endif
+
+    EEPROM::init(); // Read settings from eeprom if wanted, run after initialization!
     updateDerivedParameter();
     Commands::checkFreeMemory();
     Commands::writeLowestFreeRAM();
     HAL::setupTimer();
 
-#if SDSUPPORT
-    sd.mount();
-#endif
+
 #if FEATURE_WATCHDOG
     HAL::startWatchdog();
 #endif

--- a/src/Repetier/src/Repetier.h
+++ b/src/Repetier/src/Repetier.h
@@ -574,8 +574,9 @@ public:
     static void printEscapeChars(const char* s);
 #endif
     void ls(const char* lsDir = Com::tSlash, const bool json = false);
-    void ls(sd_file_t rootDir, const bool json = false); // Will auto close rootdir
-    void mount();
+    void ls(sd_file_t& rootDir, const bool json = false); // Will auto close rootdir
+
+    void mount(const bool manual);
     void unmount(const bool manual);
     void automount();
 
@@ -655,8 +656,8 @@ public:
 
     bool scheduledPause;
     bool scheduledStop;
-    millis_t lastWriteTimeMS; 
-    uint32_t writtenBytes; // M Todo: Display written bytes recieved during the process.
+    millis_t lastWriteTimeMS;
+    uint32_t writtenBytes;
 #if JSON_OUTPUT
     GCodeFileInfo fileInfo;
 #endif

--- a/src/Repetier/src/communication/MCodes.cpp
+++ b/src/Repetier/src/communication/MCodes.cpp
@@ -166,12 +166,7 @@ void __attribute__((weak)) MCode_20(GCode* com) {
 
 void __attribute__((weak)) MCode_21(GCode* com) {
 #if SDSUPPORT
-    if (sd.state >= SDState::SD_MOUNTED) { // Some hosts (BTT TFT's) require a response after M21 or will hang.
-        Com::writeToAll = true;
-        Com::printFLN(PSTR("SD card ok"));
-    } else {
-        sd.mount();
-    }
+    sd.mount(true); 
 #endif
 }
 

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -848,8 +848,8 @@ void directAction(GUIAction action, void* data) {
 #if SDSUPPORT  
         if (sd.state == SDState::SD_HAS_ERROR) { 
             sd.unmount(true);
-        } 
-        sd.mount();
+        }
+        sd.mount(true);
 #endif
         break;
     case GUI_DIRECT_ACTION_STOP_PRINT:


### PR DESCRIPTION
Some more SD related fixes. 
- Fixed an erroneous write timeout when sometimes beginning to write files.
- Volume label would sometimes have it's last character trimmed.
- SD mounting now correctly retries 3 times when manually mounting too. Would sometimes fail at Printer::setup. 

- Mounting and importing the SD card now takes place before eeprom init, allowing eeprom.bin to be checksummed for corruption. Only the SDCard type eeprom was still being corrupted whenever we modify/add eeprom options.

Well, In this commit I haven't added any restoreEEPROMSettingsFromConfiguration when it happens, so the corrupted settings are actually still set and applied right now.

I see storeDataIntoEEPROM has an unused corrupted parameter, but I'm not sure if it was deprecated for something else recently?
Or should I just quickly put in a restoreEEPROM there and add it to the pull?   
