### PR TITLE
GUI - Allow Compiling-out encoder repeat features

### DIFF
--- a/src/Repetier/src/Configuration.h
+++ b/src/Repetier/src/Configuration.h
@@ -92,7 +92,7 @@
 #define ENCODER_SPEED 1
 
 // Dynamically increase the speed at which we step through the menus/change values.
-// Set ENCODER_MAX_REPEAT_STEPS to 1 to disable this. Also stored in EEPROM.
+// Set ENCODER_MAX_REPEAT_STEPS to 1 to disable this. EEPROM/Runtime configurable. (Set to 0 to compile out entirely for extra RAM)
 #define ENCODER_MAX_REPEAT_STEPS 5            // Max. extra steps we can gain.
 #define ENCODER_MAX_REPEAT_TIME_MS 40         // Max. time we have before our extra steps reset.
 #define ENCODER_MIN_REPEAT_TIME_MS 15         // At this repeat rate we accumulate to the max step speed.

--- a/src/Repetier/src/controller/drivers/Display20x4.cpp
+++ b/src/Repetier/src/controller/drivers/Display20x4.cpp
@@ -792,7 +792,7 @@ void GUI::menuStart(GUIAction action) {
 }
 
 void GUI::menuEnd(GUIAction action, bool scrollbar, bool affectedBySpeed) {
-    if (affectedBySpeed && GUI::speedAffectMenus) {
+    if (affectedBySpeed) {
         GUI::menuAffectBySpeed(action);
     }
     if (action == GUIAction::NEXT) {

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -214,7 +214,7 @@ void GUI::menuStart(GUIAction action) {
 }
 
 void GUI::menuEnd(GUIAction action, bool scrollbar, bool affectedBySpeed) {
-    if (affectedBySpeed && GUI::speedAffectMenus) {
+    if (affectedBySpeed) {
         GUI::menuAffectBySpeed(action);
     }
     if (action == GUIAction::NEXT) {

--- a/src/Repetier/src/controller/gui.h
+++ b/src/Repetier/src/controller/gui.h
@@ -160,11 +160,13 @@ public:
     static fast8_t bufPos;                       ///< Pos for appending data
     static GUIAction nextAction;                 ///< Next action to execute on opdate
     static int nextActionRepeat;                 ///< Increment for next/previous
+#if ENCODER_MAX_REPEAT_STEPS != 0
     static bool speedAffectMenus;                ///< Apply encoder step speed to menus
     static uint8_t maxActionRepeatStep;          ///< Max amount of extra encoder repeat steps
     static uint16_t maxActionRepeatTimeMS;       ///< Clicks longer than this will not recieve any extra steps
     static uint16_t minActionRepeatTimeMS;       ///
     static millis_t lastActionRepeatDiffMS;      ///< Just used to display the time diff in the encoder speed menu
+#endif
 
     static uint16_t eprStart;
     static GUIStatusLevel statusLevel;

--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -530,6 +530,7 @@ void __attribute__((weak)) menuTempConfig(GUIAction action, void* data) {
     GUI::menuEnd(action);
 }
 
+#if ENCODER_MAX_REPEAT_STEPS != 0
 void __attribute__((weak)) menuEncoderMaxRepeatSteps(GUIAction action, void* data) {
     DRAW_LONG_P(PSTR("Max. repeat steps:"), "steps/click", GUI::maxActionRepeatStep);
     if (GUI::handleLongValueAction(action, v, 1, 15, 1)) {
@@ -547,7 +548,7 @@ void __attribute__((weak)) menuEncoderMinRepeatTime(GUIAction action, void* data
     if (GUI::handleLongValueAction(action, v, 1, GUI::maxActionRepeatTimeMS - 1u, 1)) {
         GUI::minActionRepeatTimeMS = v;
     }
-} 
+}
 void __attribute__((weak)) menuConfigEncoder(GUIAction action, void* data) {
     GUI::menuStart(action);
     GUI::menuTextP(action, PSTR("= Config Encoder ="), true);
@@ -571,6 +572,7 @@ void __attribute__((weak)) menuConfigEncoder(GUIAction action, void* data) {
     GUI::menuOnOffP(action, PSTR("Affect in menus:"), GUI::speedAffectMenus, directAction, (void*)GUI_DIRECT_ACTION_TOGGLE_ENCODER_AFFECT_MENUS_BY_SPEED, GUIPageType::ACTION);
     GUI::menuEnd(action);
 }
+#endif
 #if NUM_TOOLS > 1
 void dittoToTmpString(int32_t mode, bool mirror) {
     if (mode == 0) {
@@ -1007,7 +1009,9 @@ void __attribute__((weak)) menuConfig(GUIAction action, void* data) {
 #endif
         }
     }
+#if ENCODER_MAX_REPEAT_STEPS != 0
     GUI::menuSelectableP(action, PSTR("Encoder"), menuConfigEncoder, nullptr, GUIPageType::MENU);
+#endif
     GUI::menuSelectableP(action, PSTR("Store Settings"), directAction, (void*)GUI_DIRECT_ACTION_STORE_EEPROM, GUIPageType::ACTION);
     GUI::menuSelectableP(action, PSTR("Factory Reset"), directAction, (void*)GUI_DIRECT_ACTION_FACTORY_RESET, GUIPageType::ACTION);
     GUI::menuEnd(action);


### PR DESCRIPTION
Setting ENCODER_MAX_REPEAT_STEPS to 0 should compile out the encoder configuration stuff. 