### PR TITLE
STM32F1 (Mini E3) - Add flto flag & enable dedicated SPI 

### DIFF
--- a/src/Repetier/platformio.ini
+++ b/src/Repetier/platformio.ini
@@ -106,6 +106,7 @@ build_flags                 =
     ${common.build_flags}
     -DWORKAREASIZE=0x800    # speedup stlink uploads a little
     -O2
+	-flto
     -DUSBD_USE_CDC 
     -DUSBCON
     -DCUSTOM_STARTUP_FILE

--- a/src/SampleSystems/Cartesian/SKR E3 Mini V1.2/Configuration.h
+++ b/src/SampleSystems/Cartesian/SKR E3 Mini V1.2/Configuration.h
@@ -150,6 +150,9 @@ to the position. 0 = no contribution. */
 #define AXISCOMP_TANYZ 0
 #define AXISCOMP_TANXZ 0
 
+// SKR E3 Mini - If not using the SPI1 pins, enable this to improve SD read/write speeds.
+#define ENABLE_DEDICATED_SPI 1
+
 // Next 7 lines are required to make the following work, do not change!
 #include "boards/pins.h"
 #undef IO_TARGET

--- a/src/SampleSystems/Cartesian/SKR E3 Mini V2/Configuration.h
+++ b/src/SampleSystems/Cartesian/SKR E3 Mini V2/Configuration.h
@@ -156,6 +156,9 @@ to the position. 0 = no contribution. */
 #define AXISCOMP_TANYZ 0
 #define AXISCOMP_TANXZ 0
 
+// SKR E3 Mini - If not using the SPI1 pins, enable this to improve SD read/write speeds.
+#define ENABLE_DEDICATED_SPI 1
+
 // Next 7 lines are required to make the following work, do not change!
 #include "boards/pins.h"
 #undef IO_TARGET


### PR DESCRIPTION
Turning on -flto for STM32F1 since the E3's flash is getting a *little* tight with all features turned on.

PS. It turns out AVR has flto turned on by default now in PIO. 
Turning it off via unflag can speed up compile time a fair bit (if you have the RAM/flash to spare.)