### PR TITLE
V2 - Misc Fixes 

### DIFF
--- a/src/Repetier/src/PrinterTypes/PrinterTypeCartesian.cpp
+++ b/src/Repetier/src/PrinterTypes/PrinterTypeCartesian.cpp
@@ -161,9 +161,7 @@ void PrinterType::updateDerived() { }
 void PrinterType::enableMotors(fast8_t axes) {
     FOR_ALL_AXES(i) {
         if ((axes & axisBits[i]) != 0 && Motion1::motors[i]) {
-            if (Motion1::motors[i]) {
-                Motion1::motors[i]->enable();
-            }
+            Motion1::motors[i]->enable();
         }
     }
     if ((axes & axisBits[E_AXIS]) != 0 && Motion1::dittoMode) {

--- a/src/Repetier/src/communication/Eeprom.cpp
+++ b/src/Repetier/src/communication/Eeprom.cpp
@@ -181,11 +181,19 @@ void EEPROM::restoreEEPROMSettingsFromConfiguration() {
     LevelingCorrector::resetEeprom();
     Leveling::resetEeprom();
     GUI::resetEeprom();
+
+    initBaudrate();
+    maxInactiveTime = MAX_INACTIVE_TIME * 1000ul;
+    stepperInactiveTime = STEPPER_INACTIVE_TIME * 1000ul;
+
     markChanged();
 }
 
 void EEPROM::storeDataIntoEEPROM(uint8_t corrupted) {
 #if EEPROM_MODE != 0
+    if (corrupted) {
+        restoreEEPROMSettingsFromConfiguration();
+    }
     Com::printFLN(PSTR("Storing data to eeprom"));
     mode = EEPROMMode::STORE;
     callHandle();
@@ -277,7 +285,7 @@ void EEPROM::init() {
         }
     } else {
         resetRec = true;
-        storeDataIntoEEPROM(storedcheck != check);
+        storeDataIntoEEPROM(!check || (storedcheck != check));
     }
     var1 = getRecoverByte(0);
     var2 = getRecoverByte(1);

--- a/src/Repetier/src/communication/Eeprom.cpp
+++ b/src/Repetier/src/communication/Eeprom.cpp
@@ -345,10 +345,11 @@ void EEPROM::updateChecksum() {
 void EEPROM::handlePrefix(PGM_P text) {
     if (mode == EEPROMMode::REPORT) {
         uint8_t i = 0;
-        while (i < 19) {
+        while (i < (sizeof(prefix) - 2)) {
             uint8_t c = pgm_read_byte(text++);
-            if (!c)
+            if (!c) {
                 break;
+            }
             prefix[i++] = c;
         }
         prefix[i++] = 32;

--- a/src/Repetier/src/communication/gcode.cpp
+++ b/src/Repetier/src/communication/gcode.cpp
@@ -208,9 +208,9 @@ uint8_t GCode::computeBinarySize(char* ptr) // unsigned int bitfield) {
     return s;
 }
 
-GCode::GCode() {
-    reset();
-}
+GCode::GCode()
+    : params(0u)
+    , params2(0u) { }
 
 void GCode::keepAlive(enum FirmwareState state, int id) {
     // Id is only for debugging to see where busy is hanging!
@@ -1227,12 +1227,12 @@ void GCodeSource::printAllFLN(FSTRINGPARAM(text), int32_t v) {
     Com::writeToAll = old;
 }
 
-GCodeSource::GCodeSource() {
-    lastLineNumber = 0;
-    wasLastCommandReceivedAsBinary = false;
-    outOfOrder = false;
-    waitingForResend = -1;
-}
+GCodeSource::GCodeSource()
+    : lastLineNumber(0u)
+    , wasLastCommandReceivedAsBinary(false)
+    , timeOfLastDataPacket(0u)
+    , waitingForResend(-1)
+    , outOfOrder(false) { }
 
 bool GCodeSource::hasBaudSources() {
     if (!usbHostSource) {

--- a/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
+++ b/src/Repetier/src/controller/drivers/DisplayU8G2.cpp
@@ -139,7 +139,7 @@ void GUI::refresh() {
 void __attribute__((weak)) drawStatusLine() {
     GUI::bufClear();
     Tool* t = Tool::getActiveTool();
-    HeatManager* hm = t->getHeater();
+    HeatManager* hm = t ? t->getHeater() : nullptr;
     if (hm != nullptr) { // E1:210/210°C
         GUI::bufAddChar('E');
         GUI::bufAddInt(t->getToolId() + 1, 1);
@@ -710,7 +710,7 @@ void GUI::showValue(char* text, PGM_P unit, char* value) {
     lcd.setDrawColor(0);
     GUI::bufClear();
     GUI::bufAddStringP(Com::tBtnOK);
-    lcd.drawUTF8(64 - 3 * strlen(GUI::buf), 62, GUI::buf);
+    lcd.drawUTF8(64 - 3 * GUI::bufPos, 62, GUI::buf);
     lcd.setDrawColor(1);
 }
 

--- a/src/Repetier/src/controller/gui.cpp
+++ b/src/Repetier/src/controller/gui.cpp
@@ -765,8 +765,6 @@ void GUI::setStatus(char* text, GUIStatusLevel lvl) {
         }
         if (lvl == GUIStatusLevel::WARNING) {
             push(warningScreen, status, GUIPageType::STATUS);
-            Printer::playDefaultSound(DefaultSounds::WARNING);
-            push(warningScreen, status, GUIPageType::STATUS);
             Com::promptStart(GUI::pop, Com::tWarning, status, false);
             Com::promptButton(Com::tOk);
             Com::promptShow();

--- a/src/Repetier/src/controller/menu.cpp
+++ b/src/Repetier/src/controller/menu.cpp
@@ -657,12 +657,11 @@ void __attribute__((weak)) menuControls(GUIAction action, void* data) {
 }
 
 void __attribute__((weak)) menuFan(GUIAction action, void* data) {
-    int id = reinterpret_cast<int>(data);
-    PWMHandler* pwm = fans[reinterpret_cast<int>(data)].fan;
-    int32_t percent = (pwm->get() * 100) / 255;
+    fast8_t id = reinterpret_cast<fast8_t>(data);
+    int32_t percent = ((fans[id].fan->get() * 100l) + 127l) / 255l;
     GUI::flashToStringLong(GUI::tmpString, PSTR("Fan @ Speed:"), id + 1);
     DRAW_LONG(GUI::tmpString, Com::tUnitPercent, percent);
-    if (GUI::handleLongValueAction(action, percent, 0, 100, 5)) {
+    if (GUI::handleLongValueAction(action, percent, 0l, 100l, 1l)) {
         Printer::setFanSpeed((percent * 255) / 100, true, id);
     }
 }
@@ -671,9 +670,8 @@ void __attribute__((weak)) menuFans(GUIAction action, void* data) {
     GUI::menuStart(action);
     GUI::menuTextP(action, PSTR("= Fans = "), true);
     GUI::menuBack(action);
-    for (int i = 0; i < NUM_FANS; i++) {
-        PWMHandler* fan = fans[i].fan;
-        int32_t percent = (fan->get() * 100) / 255;
+    for (fast8_t i = 0; i < NUM_FANS; i++) {
+        int32_t percent = ((fans[i].fan->get() * 100l) + 127l) / 255l;
         GUI::flashToStringLong(GUI::tmpString, PSTR("Fan @:"), i + 1);
         GUI::menuLong(action, GUI::tmpString, percent, menuFan, (void*)i, GUIPageType::FIXED_CONTENT);
     }

--- a/src/Repetier/src/drivers/coolerManager.h
+++ b/src/Repetier/src/drivers/coolerManager.h
@@ -42,8 +42,8 @@ public:
         , startTemp(_startTemp)
         , maxTemp(_maxTemp)
         , minPWM(_minPWM)
-        , maxPWM(_maxPWM) {
-        diff = static_cast<float>(maxPWM - minPWM) / (maxTemp - startTemp);
+        , maxPWM(_maxPWM)
+        , diff(static_cast<float>(maxPWM - minPWM) / (maxTemp - startTemp)) {
     }
     void update();
 };
@@ -72,8 +72,8 @@ public:
         , startTemp(_startTemp)
         , maxTemp(_maxTemp)
         , minPWM(_minPWM)
-        , maxPWM(_maxPWM) {
-        diff = static_cast<float>(maxPWM - minPWM) / (maxTemp - startTemp);
+        , maxPWM(_maxPWM)
+        , diff(static_cast<float>(maxPWM - minPWM) / (maxTemp - startTemp)) {
     }
     void update();
 };
@@ -92,9 +92,9 @@ public:
                         int postCoolingSeconds)
         : pwm(_pwm)
         , offPWM(_offPWM)
-        , onPWM(_onPWM) {
-        postCooling = 2 * postCoolingSeconds;
-        onCount = -1;
+        , onPWM(_onPWM)
+        , postCooling(2 * postCoolingSeconds)
+        , onCount(-1) {
         pwm->set(offPWM);
     }
     void update();

--- a/src/Repetier/src/drivers/heatManager.cpp
+++ b/src/Repetier/src/drivers/heatManager.cpp
@@ -14,7 +14,7 @@ void menuSetTemperature(GUIAction action, void* data) {
     HeatManager* hm = reinterpret_cast<HeatManager*>(data);
     float value = hm->getTargetTemperature();
     DRAW_FLOAT_P(PSTR("Target Temperature:"), Com::tUnitDegCelsius, value, 0);
-    if (GUI::handleFloatValueAction(action, value, hm->getMinTemperature(), hm->getMaxTemperature(), (ENCODER_SPEED == 2) ? 5 : 1)) {
+    if (GUI::handleFloatValueAction(action, value, hm->getMinTemperature(), hm->getMaxTemperature(), 1.0f)) {
         hm->setTargetTemperature(value);
     }
 #endif

--- a/src/Repetier/src/drivers/heatManager.cpp
+++ b/src/Repetier/src/drivers/heatManager.cpp
@@ -495,9 +495,10 @@ void HeatManagerPID::updateDerived() {
     kd = D / timeSeconds;
 }
 
-void HeatManagerPID::resetFromConfig(fast8_t _maxPwm, float decVariance, millis_t decPeriod,
+void HeatManagerPID::resetFromConfig(ufast8_t _maxPwm, float maxTemp, float decVariance, millis_t decPeriod,
                                      float p, float i, float d, float _driveMin, float _driveMax) {
     maxPWM = _maxPwm;
+    maxTemperature = maxTemp;
     decoupleVariance = decVariance;
     decouplePeriod = decPeriod;
     P = p;
@@ -1045,9 +1046,10 @@ void HeatManagerDynDeadTime::updateTimings() {
     // Com::printFLN(PSTR("DeadDown"), deadDown, 2);
 }
 
-void HeatManagerDynDeadTime::resetFromConfig(fast8_t _maxPwm, float decVariance, millis_t decPeriod,
+void HeatManagerDynDeadTime::resetFromConfig(ufast8_t _maxPwm, float maxTemp, float decVariance, millis_t decPeriod,
                                              float _temp1, float _deadUp1, float _deadDown1, float _temp2, float _deadUp2, float _deadDown2) {
     maxPWM = _maxPwm;
+    maxTemperature = maxTemp;
     decoupleVariance = decVariance;
     decouplePeriod = decPeriod;
     temp1 = _temp1;

--- a/src/Repetier/src/drivers/heatManager.h
+++ b/src/Repetier/src/drivers/heatManager.h
@@ -194,8 +194,9 @@ public:
     int eepromSize() {
         return 1;
     }
-    void resetFromConfig(fast8_t _maxPwm, float decVariance, millis_t decPeriod) {
+    void resetFromConfig(ufast8_t _maxPwm, float maxTemp, float decVariance, millis_t decPeriod) {
         maxPWM = _maxPwm;
+        maxTemperature = maxTemp;
         decoupleVariance = decVariance;
         decouplePeriod = decPeriod;
     }
@@ -230,7 +231,7 @@ public:
     }
     void updateLocal(float tempError);
     void updateDerived();
-    void resetFromConfig(fast8_t _maxPwm, float decVariance, millis_t decPeriod,
+    void resetFromConfig(ufast8_t _maxPwm, float maxTemp, float decVariance, millis_t decPeriod,
                          float p, float i, float d, float _driveMin, float _driveMax);
     void eepromHandleLocal(int adr);
     int eepromSizeLocal();
@@ -308,7 +309,7 @@ public:
         updateTimings();
     }
     void updateLocal(float tempError);
-    void resetFromConfig(fast8_t _maxPwm, float decVariance, millis_t decPeriod,
+    void resetFromConfig(ufast8_t _maxPwm, float maxTemp, float decVariance, millis_t decPeriod,
                          float _temp1, float _deadUp1, float _deadDown1, float _temp2, float _deadUp2, float _deadDown2);
     void eepromHandleLocal(int adr);
     int eepromSizeLocal();

--- a/src/Repetier/src/drivers/heatManager.h
+++ b/src/Repetier/src/drivers/heatManager.h
@@ -145,11 +145,11 @@ public:
     inline millis_t getDecouplePeriod() { return decouplePeriod; }
     inline void setDecouplePeriod(millis_t val) { decouplePeriod = val; }
     inline float getHysteresisTemperature() { return hysteresisTemperature; }
-    inline void setHysteresisTemperature(float val) { hysteresisTemperature = val >= 0 ? val : 0; }
+    inline void setHysteresisTemperature(float val) { hysteresisTemperature = val >= 0.0f ? val : 0.0f; }
     inline millis_t getHysteresisTime() { return hysteresisTime; }
-    inline void setHysteresisTime(millis_t val) { hysteresisTime = val >= 0 ? val : 0; }
+    inline void setHysteresisTime(millis_t val) { hysteresisTime = val; }
     inline millis_t getMaxWait() { return maxWait; }
-    inline void setMaxWait(millis_t val) { maxWait = val >= 0 ? val : 0; }
+    inline void setMaxWait(millis_t val) { maxWait = val; }
     virtual void updateLocal(float tempError) = 0;
     void eepromHandle();
     virtual void eepromHandleLocal(int pos) = 0;

--- a/src/Repetier/src/io/io_heatManager.h
+++ b/src/Repetier/src/io/io_heatManager.h
@@ -78,13 +78,13 @@
 #elif IO_TARGET == IO_TARGET_RESTORE_FROM_CONFIG // restore from config
 
 #define HEAT_MANAGER_BANG_BANG(name, tp, index, input, output, maxTemp, maxPwm, decVariance, decPeriod, hotPlugable) \
-    name.resetFromConfig(maxPwm, decVariance, decPeriod);
+    name.resetFromConfig(maxPwm, maxTemp, decVariance, decPeriod);
 #define HEAT_MANAGER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable) \
-    name.resetFromConfig(maxPwm, decVariance, decPeriod, p, i, d, driveMin, driveMax);
+    name.resetFromConfig(maxPwm, maxTemp, decVariance, decPeriod, p, i, d, driveMin, driveMax);
 #define HEAT_MANAGER_PELTIER_PID(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, p, i, d, driveMin, driveMax, hotPlugable, pType, flowPin, minTemp) \
-    name.resetFromConfig(maxPwm, decVariance, decPeriod, p, i, d, driveMin, driveMax);
+    name.resetFromConfig(maxPwm, maxTemp, decVariance, decPeriod, p, i, d, driveMin, driveMax);
 #define HEAT_MANAGER_DYN_DEAD_TIME(name, tp, index, input, output, maxTemp, maxPwm, sampleTime, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2, hotPlugable) \
-    name.resetFromConfig(maxPwm, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2);
+    name.resetFromConfig(maxPwm, maxTemp, decVariance, decPeriod, temp1, timeUp1, timeDown1, temp2, timeUp2, timeDown2);
 #define HEAT_MANAGER_DEFINE_HYSTERESIS(name, hysteresisTemperature, hysteresisTime, maxWait) \
     name.initHysteresis(hysteresisTemperature, hysteresisTime, maxWait);
 


### PR DESCRIPTION
few small fixes (some I forgot to merge a while back ago.)
- Fixed a rounding issue in the fan menu (PWM to %)
- Fixed potential nullptr dereference in the U8G display status line 
- Fixed potential out of bounds crash in eeprom.cpp handleprefix
- Fixed heatManagers not restoring their compiled maximum temperatures on eeprom resets
- Fixed maxInactivetime/stepperInactiveTime and baudrate not restoring on eeprom corruptions/resets
- Removed duplicate screen push & playDefaultSound in setStatus's warning level
- Removed some redundant checks in the hysteresis getters/setters in heatManager.h 
- Moved some assigned variables (inside class constructors) to their class initializer lists
- Forgot to remove the (ENCODER_SPEED == 2) ? 5 : 1 check inside the heater temperature menu
