### PR TITLE
Fix missing pause/stop options after RequestPause/RequestContinue

### DIFF
--- a/src/Repetier/src/PrinterTypes/Printer.cpp
+++ b/src/Repetier/src/PrinterTypes/Printer.cpp
@@ -1294,6 +1294,9 @@ void Printer::continuePrint() {
 #endif
         if (Printer::isMenuMode(MENU_MODE_PAUSED)) {
         GCodeSource::printAllFLN(PSTR("RequestContinue:"));
+#if !defined(DISABLE_PRINTMODE_ON_PAUSE) || DISABLE_PRINTMODE_ON_PAUSE == 1
+        Printer::setPrinting(true);
+#endif
     }
     setMenuMode(MENU_MODE_PAUSED, false);
 }


### PR DESCRIPTION
The pause/continue/stop menu options would disappear when printing via RepetierServer and we did a pause then continue.
Printer::setPrinting(true) was missing from Printer::continuePrint()