### PR TITLE
Allow space in commands M23 / M30 /  M32 / M118

### DIFF
--- a/src/ArduinoAVR/Repetier/gcode.cpp
+++ b/src/ArduinoAVR/Repetier/gcode.cpp
@@ -997,7 +997,7 @@ bool GCode::parseAscii(char* line, bool fromSerial) {
                 }
                 text = pos;
                 while (*pos) {
-                    if ((M != 117 && M != 20 && M != 531 && *pos == ' ') || *pos == '*')
+                    if ((M != 117 && M != 118 && M != 20 && M != 23 && M != 30 && M != 32 && M != 531 && *pos == ' ') || *pos == '*')
                         break;
                     pos++; // find a space as file name end
                 }

--- a/src/ArduinoDUE/Repetier/gcode.cpp
+++ b/src/ArduinoDUE/Repetier/gcode.cpp
@@ -997,7 +997,7 @@ bool GCode::parseAscii(char* line, bool fromSerial) {
                 }
                 text = pos;
                 while (*pos) {
-                    if ((M != 117 && M != 20 && M != 531 && *pos == ' ') || *pos == '*')
+                    if ((M != 117 && M != 118 && M != 20 && M != 23 && M != 30 && M != 32 && M != 531 && *pos == ' ') || *pos == '*')
                         break;
                     pos++; // find a space as file name end
                 }


### PR DESCRIPTION
M20 list long name but command using this  if have a space are not working:
so this PR fix it for M23 / M30 / M32

M118 like M117 can have also space in it so sync with M117 

I have updated AVR/ DUE code- I hope is ok  - long time I did not do PR here ^_^ - let me know if I need to change something

I did not tested dev2 branch - as It seems I do not have supported board I have AVR which seems not yet ported in Readme, and my Due is dead sorry
