### PR TITLE
Fix build on macOS and don't fail with M21 silently

### DIFF
--- a/src/ArduinoAVR/Repetier/Eeprom.cpp
+++ b/src/ArduinoAVR/Repetier/Eeprom.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of Repetier-Firmware.
 
     Repetier-Firmware is free software: you can redistribute it and/or modify

--- a/src/ArduinoAVR/Repetier/SDCard.cpp
+++ b/src/ArduinoAVR/Repetier/SDCard.cpp
@@ -71,8 +71,10 @@ void SDCard::initsd() {
     sdactive = false;
 #if SDSS > -1
 #if SDCARDDETECT > -1
-    if (READ(SDCARDDETECT) != SDCARDDETECTINVERTED)
+    if (READ(SDCARDDETECT) != SDCARDDETECTINVERTED) {
+        Com::printFLN(Com::tSDInitFail);
         return;
+    }
 #endif
     HAL::pingWatchdog();
     HAL::delayMilliseconds(50); // wait for stabilization of contacts, bootup ...

--- a/src/ArduinoDUE/Repetier/Eeprom.cpp
+++ b/src/ArduinoDUE/Repetier/Eeprom.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of Repetier-Firmware.
 
     Repetier-Firmware is free software: you can redistribute it and/or modify

--- a/src/ArduinoDUE/Repetier/SDCard.cpp
+++ b/src/ArduinoDUE/Repetier/SDCard.cpp
@@ -71,8 +71,10 @@ void SDCard::initsd() {
     sdactive = false;
 #if SDSS > -1
 #if SDCARDDETECT > -1
-    if (READ(SDCARDDETECT) != SDCARDDETECTINVERTED)
+    if (READ(SDCARDDETECT) != SDCARDDETECTINVERTED) {
+        Com::printFLN(Com::tSDInitFail);
         return;
+    }
 #endif
     HAL::pingWatchdog();
     HAL::delayMilliseconds(50); // wait for stabilization of contacts, bootup ...


### PR DESCRIPTION
1)
    Fix build on macOS due to unwanted characters.

    Building fails with:
````
    Eeprom.cpp:1:1: error: stray '\357' in program
     /*
     ^
    Eeprom.cpp:1:2: error: stray '\273' in program
     /*
      ^
    Eeprom.cpp:1:3: error: stray '\277' in program
     /*
       ^
````

2)  M21 command (sd card init) fails silently.

When there is no sd card then M21 just fails silently:

````
    Send: N3 M21*19
    Recv: ok 3
````

which confuses octoprint. Since no failure was reported octoprint thinks
sd card is supported while in reality it is not.

With this patch failure is properly signalled:

````
    Send: N9 M21*25
    Recv: ok 9
    Recv: SD init fail
````

When sd card is inserted and M21 is issued:

````
    Send: N10 M21*33
    Recv: ok 10
    Recv: Card successfully initialized.
````

Happens on RAMPS 1.4 board.