### PR TITLE
[BUGFIX] text message length is not validated for binary protocol v2

### DIFF
--- a/src/ArduinoAVR/Repetier/gcode.cpp
+++ b/src/ArduinoAVR/Repetier/gcode.cpp
@@ -834,7 +834,7 @@ bool GCode::parseBinary(uint8_t* buffer, fast8_t length, bool fromSerial) {
         params2 = *(uint16_t*)p;
         p += 2;
         if (hasString())
-            textlen = *p++;
+            textlen = RMath::min(80, *p++ + 1);;
     } else
         params2 = 0;
     if (params & 1) {


### PR DESCRIPTION
While performing a fuzzing campaign on different G-Code parsers, I stumbled across this bug. It allows the null-terminator of the text message to be written up to 255 Bytes away from the beginning of the text message inside the "commandReceiving" buffer, leading to a global buffer overflow. It is caused by a missing validation of the text length, that is included in the binary protocol V2. Fixing this bug is just as easy as letting the "textlen" variable be no higher than 80, just as it is done in the "computeBinarySize" function.